### PR TITLE
⚽️ Enhance agent icon palette with dark/light themes and installation status

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -51,6 +51,7 @@ const copyCliHubAssets = () => {
 	fs.mkdirSync(outDir, { recursive: true });
 	fs.copyFileSync(path.join('src', 'clihub', 'index.html'), path.join(outDir, 'index.html'));
 	fs.copyFileSync(path.join('src', 'clihub', 'global.css'), path.join(outDir, 'global.css'));
+	copyDirectoryAssets(path.join('src', 'clihub', 'assets'), path.join(outDir, 'assets'));
 	copyDirectoryAssets(path.join('src', 'clihub', 'webview'), path.join(outDir, 'webview'));
 	copyXtermAssets(outDir);
 };
@@ -72,7 +73,7 @@ const watchCliHubAssets = () => {
 			}
 
 			const extension = path.extname(fileName.toString());
-			if (extension === '.html' || extension === '.css') {
+			if (extension === '.html' || extension === '.css' || extension === '.svg') {
 				scheduleCopy();
 			}
 		});

--- a/src/clihub/global.css
+++ b/src/clihub/global.css
@@ -205,13 +205,20 @@ body {
 	width: 6px;
 	height: 6px;
 	border-radius: 999px;
-	background: var(--vscode-testing-iconPassed, #73c991);
+	background: #2fd67b;
 	font-size: 0;
 	box-shadow: 0 0 0 1px var(--bg-color);
 }
 
 .agent-icon-option.is-missing .agent-icon-status {
 	background: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.8));
+}
+
+.agent-icon-option.is-preview .agent-icon-status {
+	background: var(--accent-color);
+	box-shadow:
+		0 0 0 1px var(--bg-color),
+		0 0 8px color-mix(in srgb, var(--accent-color) 70%, transparent);
 }
 
 .selected-model {

--- a/src/clihub/global.css
+++ b/src/clihub/global.css
@@ -171,6 +171,23 @@ body {
 	filter: grayscale(1) saturate(0) opacity(0.72);
 }
 
+/*  Color icon dark and light */
+.vscode-dark .agent-icon-option.has-dark-icon:not(.is-missing) .agent-icon-image {
+	filter: invert(1) brightness(1.22) contrast(0.92);
+}
+
+.vscode-dark .agent-icon-option.has-dark-icon.is-missing .agent-icon-image {
+	filter: grayscale(1) invert(1) brightness(0.72) opacity(0.48);
+}
+
+.vscode-high-contrast .agent-icon-option.has-dark-icon:not(.is-missing) .agent-icon-image {
+	filter: invert(1) brightness(1.42) contrast(1.08);
+}
+
+.vscode-high-contrast .agent-icon-option.has-dark-icon.is-missing .agent-icon-image {
+	filter: grayscale(1) invert(1) brightness(0.86) opacity(0.62);
+}
+
 .agent-icon-image {
 	width: 24px;
 	height: 24px;

--- a/src/clihub/global.css
+++ b/src/clihub/global.css
@@ -197,6 +197,14 @@ body {
 	filter: grayscale(1) invert(1) brightness(0.86) opacity(0.62);
 }
 
+.vscode-light .agent-icon-option.has-light-icon:not(.is-missing) .agent-icon-image {
+	filter: invert(1) brightness(0.42) contrast(1.45);
+}
+
+.vscode-light .agent-icon-option.has-light-icon.is-missing .agent-icon-image {
+	filter: grayscale(1) invert(1) brightness(0.36) opacity(0.52);
+}
+
 .agent-icon-image {
 	width: 24px;
 	height: 24px;

--- a/src/clihub/global.css
+++ b/src/clihub/global.css
@@ -150,17 +150,17 @@ body {
 	transition: background-color 140ms ease, border-color 140ms ease, opacity 140ms ease, transform 140ms ease;
 }
 
-.agent-icon-option:hover,
-.agent-icon-option:focus-visible {
+.agent-icon-option:hover {
 	border-color: color-mix(in srgb, var(--accent-color) 46%, transparent);
 	background: color-mix(in srgb, var(--accent-color) 12%, var(--vscode-input-background, rgba(128, 128, 128, 0.1)));
 	outline: none;
 	transform: translateY(-1px);
 }
 
-.agent-icon-option.is-selected {
-	border-color: color-mix(in srgb, var(--accent-color) 72%, transparent);
-	background: color-mix(in srgb, var(--accent-color) 16%, var(--vscode-input-background, rgba(128, 128, 128, 0.1)));
+.agent-icon-option:focus-visible {
+	border-color: color-mix(in srgb, var(--accent-color) 54%, transparent);
+	outline: 1px solid var(--accent-color);
+	outline-offset: 1px;
 }
 
 .agent-icon-option.is-missing {

--- a/src/clihub/global.css
+++ b/src/clihub/global.css
@@ -8,6 +8,13 @@
 	--selection-color: var(--input-border-left);
 }
 
+/* -- -- --  - Color Tab -> */
+body.has-agent-palette {
+	--accent-color: #e2b719;
+	--input-border-left: #e2b719;
+	--selection-color: #e2b719;
+}
+
 body {
 	display: flex;
 	justify-content: center;

--- a/src/clihub/global.css
+++ b/src/clihub/global.css
@@ -130,6 +130,7 @@ body {
 .agent-icon-palette.is-open {
 	max-height: 64px;
 	margin-top: 10px;
+	overflow: visible;
 	opacity: 1;
 	transform: translateY(0);
 }
@@ -151,6 +152,7 @@ body {
 }
 
 .agent-icon-option:hover {
+	z-index: 1;
 	border-color: color-mix(in srgb, var(--accent-color) 46%, transparent);
 	background: color-mix(in srgb, var(--accent-color) 12%, var(--vscode-input-background, rgba(128, 128, 128, 0.1)));
 	outline: none;

--- a/src/clihub/global.css
+++ b/src/clihub/global.css
@@ -114,6 +114,87 @@ body {
 	outline-offset: 3px;
 }
 
+.agent-icon-palette {
+	width: 100%;
+	max-height: 0;
+	margin-top: 0;
+	display: grid;
+	grid-template-columns: repeat(10, minmax(34px, 1fr));
+	gap: 6px;
+	overflow: hidden;
+	opacity: 0;
+	transform: translateY(-4px);
+	transition: max-height 180ms ease, margin-top 180ms ease, opacity 140ms ease, transform 180ms ease;
+}
+
+.agent-icon-palette.is-open {
+	max-height: 64px;
+	margin-top: 10px;
+	opacity: 1;
+	transform: translateY(0);
+}
+
+.agent-icon-option {
+	position: relative;
+	min-width: 0;
+	height: 42px;
+	border: 1px solid transparent;
+	border-radius: 6px;
+	padding: 7px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: color-mix(in srgb, var(--vscode-input-background, rgba(128, 128, 128, 0.1)) 84%, transparent);
+	color: var(--text-color);
+	cursor: pointer;
+	transition: background-color 140ms ease, border-color 140ms ease, opacity 140ms ease, transform 140ms ease;
+}
+
+.agent-icon-option:hover,
+.agent-icon-option:focus-visible {
+	border-color: color-mix(in srgb, var(--accent-color) 46%, transparent);
+	background: color-mix(in srgb, var(--accent-color) 12%, var(--vscode-input-background, rgba(128, 128, 128, 0.1)));
+	outline: none;
+	transform: translateY(-1px);
+}
+
+.agent-icon-option.is-selected {
+	border-color: color-mix(in srgb, var(--accent-color) 72%, transparent);
+	background: color-mix(in srgb, var(--accent-color) 16%, var(--vscode-input-background, rgba(128, 128, 128, 0.1)));
+}
+
+.agent-icon-option.is-missing {
+	opacity: 0.52;
+}
+
+.agent-icon-option.is-missing .agent-icon-image {
+	filter: grayscale(1) saturate(0) opacity(0.72);
+}
+
+.agent-icon-image {
+	width: 24px;
+	height: 24px;
+	display: block;
+	object-fit: contain;
+	pointer-events: none;
+}
+
+.agent-icon-status {
+	position: absolute;
+	right: 5px;
+	bottom: 5px;
+	width: 6px;
+	height: 6px;
+	border-radius: 999px;
+	background: var(--vscode-testing-iconPassed, #73c991);
+	font-size: 0;
+	box-shadow: 0 0 0 1px var(--bg-color);
+}
+
+.agent-icon-option.is-missing .agent-icon-status {
+	background: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.8));
+}
+
 .selected-model {
 	background-color: color-mix(in srgb, var(--vscode-testing-iconPassed, #73c991) 20%, transparent);
 	border-radius: 5px;
@@ -162,4 +243,14 @@ body {
 @keyframes pulseGlow {
 	0%, 100% { filter: drop-shadow(0 0 3px var(--accent-color)); }
 	50% { filter: drop-shadow(0 0 8px var(--accent-color)) brightness(1.2); }
+}
+
+@media (max-width: 560px) {
+	.agent-icon-palette {
+		grid-template-columns: repeat(5, minmax(34px, 1fr));
+	}
+
+	.agent-icon-palette.is-open {
+		max-height: 116px;
+	}
 }

--- a/src/clihub/index.html
+++ b/src/clihub/index.html
@@ -205,7 +205,7 @@
 					const options = [...agentIconPalette.querySelectorAll('.agent-icon-option')];
 					const index = options.indexOf(option);
 
-					if (event.key === 'Tab' && !event.shiftKey) {
+					if (event.key === 'Tab') {
 						event.preventDefault();
 						setPaletteOpen(false);
 						cliInput.focus();
@@ -272,11 +272,18 @@
 				return;
 			}
 
-				if (event.key === 'Tab' && !event.shiftKey) {
+			if (event.key === 'Tab') {
+				if (!event.shiftKey) {
 					event.preventDefault();
 					setPaletteOpen(!paletteOpen);
 					return;
 				}
+
+				if (paletteOpen) {
+					event.preventDefault();
+					setPaletteOpen(false);
+				}
+			}
 
 			if (event.key === 'Escape' && paletteOpen) {
 				event.preventDefault();

--- a/src/clihub/index.html
+++ b/src/clihub/index.html
@@ -16,16 +16,18 @@
 | |___| |___ | |   <span class="hub-text"> |  _  | |_| | |_) |</span>
  \____|_____|___|  <span class="hub-text"> |_| |_|\__,_|_.__/ </span>
 		</pre>
-		
+
 		<div class="input-container">
 			<div class="input-wrapper">
-				<input id="cli-input" type="text" placeholder='Type or select one of the options...' autocomplete="off" spellcheck="false" autofocus>
+				<input id="cli-input" type="text" placeholder="Type or select one of the options..." autocomplete="off" spellcheck="false" autofocus>
 			</div>
 			<div id="selected-option" class="input-footer" role="button" tabindex="0">
 				<span class="highlight">Build</span> &middot; <span id="ai-model-name" class="animated-text">OpenCode</span><span id="secondary-suggestions" class="secondary-suggestions"></span>
 			</div>
 		</div>
-		
+
+		<div id="agent-icon-palette" class="agent-icon-palette" aria-label="CLI agents" aria-hidden="true"></div>
+
 		<div class="shortcuts">
 			<strong>Tab</strong> agents &nbsp;&nbsp; <strong>Shift+F1</strong> side panel
 		</div>
@@ -34,30 +36,24 @@
 	<div class="workspace-path">${workspacePath}</div>
 
 	<!-- NOTE:--- --- --- --- --- --- -JS-   -->
+	<script id="cli-models" type="application/json">
+		${cliModels}
+	</script>
 	<script nonce="${nonce}">
 		const vscode = acquireVsCodeApi();
-		const models = [
-  		  { label: "OpenCode", aliases: ["opencode", "open code", "op"] },
-  		  { label: "Codex CLI", aliases: ["codex", "codex cli", "code", "co", "c"] },
-  		  { label: "Claude Code", aliases: ["claude", "claude code"] },
-  		  { label: "Antigravity CLI", aliases: ["antigravity", "antigravity cli", "agy", "an", "ant"] },
-  		  { label: "GitHub Copilot CLI", aliases: ["github copilot", "copilot", "copilot cli"] },
-  		  { label: "Codeep", aliases: ["codeep", "deep"] },
-  		  { label: "Amp", aliases: ["amp"] },
-  		  { label: "Kiro CLI", aliases: ["kiro", "kiro cli"] },
-  		  { label: "Kilo Code", aliases: ["kilo", "kilo code", "code","k"] },
-  		  { label: "Grok", aliases: ["grok"] }
-		];
-	
+		const models = JSON.parse(document.getElementById('cli-models').textContent);
+
 		let currentIndex = 0;
 		let selectedModel = models[0];
 		let canOpenSelectedModel = false;
+		let paletteOpen = false;
 		let invalidInputTimer;
 		const textElement = document.getElementById('ai-model-name');
 		const secondarySuggestions = document.getElementById('secondary-suggestions');
 		const cliInput = document.getElementById('cli-input');
 		const inputContainer = document.querySelector('.input-container');
 		const selectedOption = document.getElementById('selected-option');
+		const agentIconPalette = document.getElementById('agent-icon-palette');
 
 		const getMatchScore = (model, query) => {
 			const values = [model.label.toLowerCase(), ...model.aliases];
@@ -99,6 +95,12 @@
 			}
 		};
 
+		const syncPaletteSelection = () => {
+			for (const option of agentIconPalette.querySelectorAll('.agent-icon-option')) {
+				option.classList.toggle('is-selected', option.dataset.agent === selectedModel?.label);
+			}
+		};
+
 		const showInvalidInput = () => {
 			clearTimeout(invalidInputTimer);
 			inputContainer.classList.add('has-input-error');
@@ -114,6 +116,7 @@
 			inputContainer.classList.toggle('has-selection', isSearchResult);
 			textElement.classList.toggle('selected-model', isSearchResult);
 			renderSecondarySuggestions(isSearchResult ? matches : []);
+			syncPaletteSelection();
 		};
 
 		const setNoMatch = () => {
@@ -123,7 +126,20 @@
 			inputContainer.classList.remove('has-selection');
 			textElement.classList.remove('selected-model');
 			renderSecondarySuggestions([]);
+			syncPaletteSelection();
 			showInvalidInput();
+		};
+
+		const openModel = (model) => {
+			if (!model) {
+				showInvalidInput();
+				return;
+			}
+
+			vscode.postMessage({
+				type: 'openAgent',
+				agent: model.label
+			});
 		};
 
 		const openSelectedModel = () => {
@@ -132,13 +148,103 @@
 				return;
 			}
 
-			vscode.postMessage({
-				type: 'openAgent',
-				agent: selectedModel.label
-			});
+			openModel(selectedModel);
+		};
+
+		const setPaletteOpen = (isOpen, shouldFocus = false) => {
+			paletteOpen = isOpen;
+			agentIconPalette.classList.toggle('is-open', isOpen);
+			agentIconPalette.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+
+			for (const option of agentIconPalette.querySelectorAll('.agent-icon-option')) {
+				option.tabIndex = isOpen ? 0 : -1;
+			}
+
+			if (!isOpen) {
+				return;
+			}
+
+			syncPaletteSelection();
+			if (shouldFocus) {
+				const focusedOption = agentIconPalette.querySelector('.agent-icon-option.is-selected') || agentIconPalette.querySelector('.agent-icon-option');
+				focusedOption?.focus();
+			}
+		};
+
+		const renderIconPalette = () => {
+			agentIconPalette.replaceChildren();
+
+			for (const model of models) {
+				const option = document.createElement('button');
+				option.className = 'agent-icon-option';
+				option.classList.toggle('is-installed', model.installed);
+				option.classList.toggle('is-missing', !model.installed);
+				option.type = 'button';
+				option.tabIndex = -1;
+				option.dataset.agent = model.label;
+				option.title = model.installed ? model.label : `${model.label} is not installed`;
+				option.setAttribute('aria-label', option.title);
+
+				const image = document.createElement('img');
+				image.className = 'agent-icon-image';
+				image.src = model.icon;
+				image.alt = '';
+				image.draggable = false;
+
+				const status = document.createElement('span');
+				status.className = 'agent-icon-status';
+				status.textContent = model.installed ? 'Ready' : 'Missing';
+
+				option.append(image, status);
+				option.addEventListener('click', () => openModel(model));
+				option.addEventListener('focus', () => {
+					const matches = [{ model, score: 100 }];
+					setSelectedModel(model, true, matches);
+				});
+				option.addEventListener('keydown', (event) => {
+					const options = [...agentIconPalette.querySelectorAll('.agent-icon-option')];
+					const index = options.indexOf(option);
+
+					if (event.key === 'Tab' && !event.shiftKey) {
+						event.preventDefault();
+						setPaletteOpen(false);
+						cliInput.focus();
+						return;
+					}
+
+					if (event.key === 'Enter' || event.key === ' ') {
+						event.preventDefault();
+						openModel(model);
+						return;
+					}
+
+					if (event.key === 'Escape') {
+						event.preventDefault();
+						setPaletteOpen(false);
+						cliInput.focus();
+						return;
+					}
+
+					if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+						event.preventDefault();
+						options[(index + 1) % options.length]?.focus();
+						return;
+					}
+
+					if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+						event.preventDefault();
+						options[(index - 1 + options.length) % options.length]?.focus();
+					}
+				});
+
+				agentIconPalette.append(option);
+			}
+
+			syncPaletteSelection();
 		};
 
 		cliInput.focus();
+		renderIconPalette();
 		cliInput.addEventListener('input', () => {
 			const lowerValue = cliInput.value.toLowerCase();
 			if (cliInput.value !== lowerValue) {
@@ -165,6 +271,18 @@
 		cliInput.addEventListener('keydown', (event) => {
 			if (event.key === 'Enter') {
 				openSelectedModel();
+				return;
+			}
+
+			if (event.key === 'Tab' && !event.shiftKey) {
+				event.preventDefault();
+				setPaletteOpen(!paletteOpen, true);
+				return;
+			}
+
+			if (event.key === 'Escape' && paletteOpen) {
+				event.preventDefault();
+				setPaletteOpen(false);
 			}
 		});
 
@@ -175,7 +293,7 @@
 				openSelectedModel();
 			}
 		});
-	
+
 		// Change text every 3.8s with fade animation
 		setInterval(() => {
 			if (cliInput.value.trim()) {
@@ -183,7 +301,7 @@
 			}
 
 			textElement.style.opacity = 0;
-		
+
 			setTimeout(() => {
 				currentIndex = (currentIndex + 1) % models.length;
 				setSelectedModel(models[currentIndex], false);

--- a/src/clihub/index.html
+++ b/src/clihub/index.html
@@ -95,12 +95,6 @@
 			}
 		};
 
-		const syncPaletteSelection = () => {
-			for (const option of agentIconPalette.querySelectorAll('.agent-icon-option')) {
-				option.classList.toggle('is-selected', option.dataset.agent === selectedModel?.label);
-			}
-		};
-
 		const showInvalidInput = () => {
 			clearTimeout(invalidInputTimer);
 			inputContainer.classList.add('has-input-error');
@@ -116,7 +110,6 @@
 			inputContainer.classList.toggle('has-selection', isSearchResult);
 			textElement.classList.toggle('selected-model', isSearchResult);
 			renderSecondarySuggestions(isSearchResult ? matches : []);
-			syncPaletteSelection();
 		};
 
 		const setNoMatch = () => {
@@ -126,7 +119,6 @@
 			inputContainer.classList.remove('has-selection');
 			textElement.classList.remove('selected-model');
 			renderSecondarySuggestions([]);
-			syncPaletteSelection();
 			showInvalidInput();
 		};
 
@@ -164,10 +156,8 @@
 				return;
 			}
 
-			syncPaletteSelection();
 			if (shouldFocus) {
-				const focusedOption = agentIconPalette.querySelector('.agent-icon-option.is-selected') || agentIconPalette.querySelector('.agent-icon-option');
-				focusedOption?.focus();
+				agentIconPalette.querySelector('.agent-icon-option')?.focus();
 			}
 		};
 
@@ -240,8 +230,6 @@
 
 				agentIconPalette.append(option);
 			}
-
-			syncPaletteSelection();
 		};
 
 		cliInput.focus();
@@ -275,11 +263,11 @@
 				return;
 			}
 
-			if (event.key === 'Tab' && !event.shiftKey) {
-				event.preventDefault();
-				setPaletteOpen(!paletteOpen, true);
-				return;
-			}
+				if (event.key === 'Tab' && !event.shiftKey) {
+					event.preventDefault();
+					setPaletteOpen(!paletteOpen);
+					return;
+				}
 
 			if (event.key === 'Escape' && paletteOpen) {
 				event.preventDefault();

--- a/src/clihub/index.html
+++ b/src/clihub/index.html
@@ -36,7 +36,7 @@
 	<div class="workspace-path">${workspacePath}</div>
 
 	<!-- NOTE:--- --- --- --- --- --- -JS-   -->
-	<script id="cli-models" type="application/json">
+	<script id="cli-models" type="application/json" nonce="${nonce}">
 		${cliModels}
 	</script>
 	<script nonce="${nonce}">
@@ -45,7 +45,6 @@
 
 		let currentIndex = 0;
 		let selectedModel = models[0];
-		let canOpenSelectedModel = false;
 		let paletteOpen = false;
 		let invalidInputTimer;
 		const textElement = document.getElementById('ai-model-name');
@@ -95,6 +94,12 @@
 			}
 		};
 
+		const syncPreviewIndicator = () => {
+			for (const option of agentIconPalette.querySelectorAll('.agent-icon-option')) {
+				option.classList.toggle('is-preview', option.dataset.agent === selectedModel?.label);
+			}
+		};
+
 		const showInvalidInput = () => {
 			clearTimeout(invalidInputTimer);
 			inputContainer.classList.add('has-input-error');
@@ -105,20 +110,20 @@
 
 		const setSelectedModel = (model, isSearchResult, matches = []) => {
 			selectedModel = model;
-			canOpenSelectedModel = isSearchResult;
 			textElement.textContent = model.label;
 			inputContainer.classList.toggle('has-selection', isSearchResult);
 			textElement.classList.toggle('selected-model', isSearchResult);
 			renderSecondarySuggestions(isSearchResult ? matches : []);
+			syncPreviewIndicator();
 		};
 
 		const setNoMatch = () => {
 			selectedModel = undefined;
-			canOpenSelectedModel = false;
 			textElement.textContent = 'No matching CLI';
 			inputContainer.classList.remove('has-selection');
 			textElement.classList.remove('selected-model');
 			renderSecondarySuggestions([]);
+			syncPreviewIndicator();
 			showInvalidInput();
 		};
 
@@ -135,7 +140,7 @@
 		};
 
 		const openSelectedModel = () => {
-			if (!selectedModel || !canOpenSelectedModel) {
+			if (!selectedModel) {
 				showInvalidInput();
 				return;
 			}
@@ -159,6 +164,8 @@
 			if (shouldFocus) {
 				agentIconPalette.querySelector('.agent-icon-option')?.focus();
 			}
+
+			syncPreviewIndicator();
 		};
 
 		const renderIconPalette = () => {

--- a/src/clihub/index.html
+++ b/src/clihub/index.html
@@ -178,6 +178,7 @@
 				option.classList.toggle('is-installed', model.installed);
 				option.classList.toggle('is-missing', !model.installed);
 				option.classList.toggle('has-dark-icon', model.darkIcon === true);
+				option.classList.toggle('has-light-icon', model.lightIcon === true);
 				option.type = 'button';
 				option.tabIndex = -1;
 				option.dataset.agent = model.label;

--- a/src/clihub/index.html
+++ b/src/clihub/index.html
@@ -150,6 +150,7 @@
 
 		const setPaletteOpen = (isOpen, shouldFocus = false) => {
 			paletteOpen = isOpen;
+			document.body.classList.toggle('has-agent-palette', isOpen);
 			agentIconPalette.classList.toggle('is-open', isOpen);
 			agentIconPalette.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
 

--- a/src/clihub/index.html
+++ b/src/clihub/index.html
@@ -179,6 +179,7 @@
 				option.className = 'agent-icon-option';
 				option.classList.toggle('is-installed', model.installed);
 				option.classList.toggle('is-missing', !model.installed);
+				option.classList.toggle('has-dark-icon', model.darkIcon === true);
 				option.type = 'button';
 				option.tabIndex = -1;
 				option.dataset.agent = model.label;

--- a/src/clihub/main.ts
+++ b/src/clihub/main.ts
@@ -33,6 +33,15 @@ const launcherAgents: LauncherAgent[] = [
 	{ label: 'Grok', aliases: ['grok'], iconFile: 'grok.svg', darkIcon: true }
 ];
 
+const serializeJsonForHtmlScript = (value: unknown) => {
+	return JSON.stringify(value)
+		.replace(/</g, '\\u003c')
+		.replace(/>/g, '\\u003e')
+		.replace(/&/g, '\\u0026')
+		.replace(/\u2028/g, '\\u2028')
+		.replace(/\u2029/g, '\\u2029');
+};
+
 export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
 	public static readonly viewType = 'f1.cliHub';
 	private readonly sessionManager = new CliSessionManager();
@@ -126,7 +135,7 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 		html = html.replace('${styleUri}', styleUri.toString());
 		html = html.replace('${contentSecurityPolicy}', contentSecurityPolicy);
 		html = html.replace(/\$\{nonce\}/g, nonce);
-		html = html.replace('${cliModels}', JSON.stringify(launcherModels));
+		html = html.replace('${cliModels}', serializeJsonForHtmlScript(launcherModels));
 
 		html = html.replace('${workspacePath}', this._getWorkspacePath());
 

--- a/src/clihub/main.ts
+++ b/src/clihub/main.ts
@@ -17,10 +17,11 @@ type LauncherAgent = {
 	aliases: string[];
 	iconFile: string;
 	darkIcon?: boolean;
+	lightIcon?: boolean;
 };
 
 const launcherAgents: LauncherAgent[] = [
-	{ label: 'OpenCode', aliases: ['opencode', 'open code', 'op'], iconFile: 'opencode.svg' },
+	{ label: 'OpenCode', aliases: ['opencode', 'open code', 'op'], iconFile: 'opencode.svg', lightIcon: true },
 	{ label: 'Codex CLI', aliases: ['codex', 'codex cli', 'code', 'co', 'c'], iconFile: 'codex.svg' },
 	{ label: 'Claude Code', aliases: ['claude', 'claude code'], iconFile: 'claudecode.svg' },
 	{ label: 'Antigravity CLI', aliases: ['antigravity', 'antigravity cli', 'agy', 'an', 'ant'], iconFile: 'Antigravity_cli.svg' },
@@ -117,6 +118,7 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 			aliases: agent.aliases,
 			icon: this._getWebviewUri(webview, 'assets', 'icons-cli', agent.iconFile),
 			darkIcon: agent.darkIcon === true,
+			lightIcon: agent.lightIcon === true,
 			installed: installedByLabel.get(agent.label) === true
 		}));
 

--- a/src/clihub/main.ts
+++ b/src/clihub/main.ts
@@ -2,8 +2,8 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
 import * as path from 'path';
-import { allowedAgents, getCliAgent } from './webview/core/terminal-cli/agents';
-import { ensureCliInstalled } from './webview/core/terminal-cli/installation';
+import { allowedAgents, cliAgents, getCliAgent } from './webview/core/terminal-cli/agents';
+import { ensureCliInstalled, isCliInstalled } from './webview/core/terminal-cli/installation';
 import { CliSessionManager } from './webview/core/terminal-cli/session-manager';
 import { getCliHubWebviewHtml } from './webview/index';
 
@@ -12,6 +12,25 @@ type CliHubMessage = {
 	agent?: string;
 };
 
+type LauncherAgent = {
+	label: string;
+	aliases: string[];
+	iconFile: string;
+};
+
+const launcherAgents: LauncherAgent[] = [
+	{ label: 'OpenCode', aliases: ['opencode', 'open code', 'op'], iconFile: 'opencode.svg' },
+	{ label: 'Codex CLI', aliases: ['codex', 'codex cli', 'code', 'co', 'c'], iconFile: 'codex.svg' },
+	{ label: 'Claude Code', aliases: ['claude', 'claude code'], iconFile: 'claudecode.svg' },
+	{ label: 'Antigravity CLI', aliases: ['antigravity', 'antigravity cli', 'agy', 'an', 'ant'], iconFile: 'Antigravity_cli.svg' },
+	{ label: 'GitHub Copilot CLI', aliases: ['github copilot', 'copilot', 'copilot cli'], iconFile: 'github-copilot.svg' },
+	{ label: 'Codeep', aliases: ['codeep', 'deep'], iconFile: 'Codeep.svg' },
+	{ label: 'Amp', aliases: ['amp'], iconFile: 'amp.svg' },
+	{ label: 'Kiro CLI', aliases: ['kiro', 'kiro cli'], iconFile: 'kiro.svg' },
+	{ label: 'Kilo Code', aliases: ['kilo', 'kilo code', 'code', 'k'], iconFile: 'kilocode.svg' },
+	{ label: 'Grok', aliases: ['grok'], iconFile: 'grok.svg' }
+];
+
 export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
 	public static readonly viewType = 'f1.cliHub';
 	private readonly sessionManager = new CliSessionManager();
@@ -19,7 +38,7 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 
 	constructor(private readonly _extensionUri: vscode.Uri) {}
 
-	public resolveWebviewView(
+	public async resolveWebviewView(
 		webviewView: vscode.WebviewView,
 		context: vscode.WebviewViewResolveContext,
 		_token: vscode.CancellationToken,
@@ -29,7 +48,7 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 			localResourceRoots: [this._getCliHubAssetUri()]
 		};
 
-		webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+		webviewView.webview.html = await this._getHtmlForWebview(webviewView.webview);
 		webviewView.onDidDispose(() => {
 			this.sessionManager.detach();
 		});
@@ -47,7 +66,7 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 
 			if (message.type === 'backToLauncher') {
 				this.sessionManager.detach();
-				webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+				webviewView.webview.html = await this._getHtmlForWebview(webviewView.webview);
 				return;
 			}
 
@@ -74,7 +93,7 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 		this.sessionManager.dispose();
 	}
 
-	private _getHtmlForWebview(webview: vscode.Webview) {
+	private async _getHtmlForWebview(webview: vscode.Webview) {
 		const htmlPath = this._getCliHubAssetUri('index.html');
 		const stylePath = this._getCliHubAssetUri('global.css');
 
@@ -82,14 +101,28 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 		const nonce = this._getNonce();
 		const contentSecurityPolicy = [
 			"default-src 'none'",
+			`img-src ${webview.cspSource} data:`,
 			`style-src ${webview.cspSource}`,
 			`script-src 'nonce-${nonce}'`
 		].join('; ');
+
+		const installedByLabel = new Map(
+			await Promise.all(
+				cliAgents.map(async (agent) => [agent.label, await isCliInstalled(agent)] as const)
+			)
+		);
+		const launcherModels = launcherAgents.map((agent) => ({
+			label: agent.label,
+			aliases: agent.aliases,
+			icon: this._getWebviewUri(webview, 'assets', 'icons-cli', agent.iconFile),
+			installed: installedByLabel.get(agent.label) === true
+		}));
 
 		let html = fs.readFileSync(htmlPath.fsPath, 'utf8');
 		html = html.replace('${styleUri}', styleUri.toString());
 		html = html.replace('${contentSecurityPolicy}', contentSecurityPolicy);
 		html = html.replace('${nonce}', nonce);
+		html = html.replace('${cliModels}', JSON.stringify(launcherModels));
 
 		html = html.replace('${workspacePath}', this._getWorkspacePath());
 

--- a/src/clihub/main.ts
+++ b/src/clihub/main.ts
@@ -123,7 +123,7 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 		let html = fs.readFileSync(htmlPath.fsPath, 'utf8');
 		html = html.replace('${styleUri}', styleUri.toString());
 		html = html.replace('${contentSecurityPolicy}', contentSecurityPolicy);
-		html = html.replace('${nonce}', nonce);
+		html = html.replace(/\$\{nonce\}/g, nonce);
 		html = html.replace('${cliModels}', JSON.stringify(launcherModels));
 
 		html = html.replace('${workspacePath}', this._getWorkspacePath());

--- a/src/clihub/main.ts
+++ b/src/clihub/main.ts
@@ -16,6 +16,7 @@ type LauncherAgent = {
 	label: string;
 	aliases: string[];
 	iconFile: string;
+	darkIcon?: boolean;
 };
 
 const launcherAgents: LauncherAgent[] = [
@@ -23,12 +24,12 @@ const launcherAgents: LauncherAgent[] = [
 	{ label: 'Codex CLI', aliases: ['codex', 'codex cli', 'code', 'co', 'c'], iconFile: 'codex.svg' },
 	{ label: 'Claude Code', aliases: ['claude', 'claude code'], iconFile: 'claudecode.svg' },
 	{ label: 'Antigravity CLI', aliases: ['antigravity', 'antigravity cli', 'agy', 'an', 'ant'], iconFile: 'Antigravity_cli.svg' },
-	{ label: 'GitHub Copilot CLI', aliases: ['github copilot', 'copilot', 'copilot cli'], iconFile: 'github-copilot.svg' },
+	{ label: 'GitHub Copilot CLI', aliases: ['github copilot', 'copilot', 'copilot cli'], iconFile: 'github-copilot.svg', darkIcon: true },
 	{ label: 'Codeep', aliases: ['codeep', 'deep'], iconFile: 'Codeep.svg' },
 	{ label: 'Amp', aliases: ['amp'], iconFile: 'amp.svg' },
 	{ label: 'Kiro CLI', aliases: ['kiro', 'kiro cli'], iconFile: 'kiro.svg' },
-	{ label: 'Kilo Code', aliases: ['kilo', 'kilo code', 'code', 'k'], iconFile: 'kilocode.svg' },
-	{ label: 'Grok', aliases: ['grok'], iconFile: 'grok.svg' }
+	{ label: 'Kilo Code', aliases: ['kilo', 'kilo code', 'code', 'k'], iconFile: 'kilocode.svg', darkIcon: true },
+	{ label: 'Grok', aliases: ['grok'], iconFile: 'grok.svg', darkIcon: true }
 ];
 
 export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
@@ -115,6 +116,7 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 			label: agent.label,
 			aliases: agent.aliases,
 			icon: this._getWebviewUri(webview, 'assets', 'icons-cli', agent.iconFile),
+			darkIcon: agent.darkIcon === true,
 			installed: installedByLabel.get(agent.label) === true
 		}));
 

--- a/src/clihub/webview/core/terminal-cli/installation.ts
+++ b/src/clihub/webview/core/terminal-cli/installation.ts
@@ -37,8 +37,12 @@ const getInstallCommand = (installer: CliInstaller) => {
 	return installer.installCommand;
 };
 
+export const isCliInstalled = (agent: CliAgent) => {
+	return commandExists(agent.command);
+};
+
 export const ensureCliInstalled = async (agent: CliAgent) => {
-	if (await commandExists(agent.command)) {
+	if (await isCliInstalled(agent)) {
 		return true;
 	}
 


### PR DESCRIPTION
This pull request introduces a new agent icon palette to the CLI Hub launcher, allowing users to visually select CLI agents and see their installation status. It also refactors how agent data is provided to the frontend and improves asset handling and accessibility. The most important changes are grouped below:

**Frontend: Agent Icon Palette and UI Enhancements**

* Added an interactive agent icon palette (`.agent-icon-palette`) to the CLI Hub UI, with keyboard navigation, accessibility improvements, and visual feedback for installed/missing agents. The palette supports previewing and selecting agents via keyboard or mouse. (`src/clihub/index.html`, `src/clihub/global.css`) [[1]](diffhunk://#diff-2edacf992c2069bb9ce56acd7e71a36a31f2c4b44322157d001689a907e3e033L22-R30) [[2]](diffhunk://#diff-2edacf992c2069bb9ce56acd7e71a36a31f2c4b44322157d001689a907e3e033R39-R55) [[3]](diffhunk://#diff-2edacf992c2069bb9ce56acd7e71a36a31f2c4b44322157d001689a907e3e033R97-R102) [[4]](diffhunk://#diff-2edacf992c2069bb9ce56acd7e71a36a31f2c4b44322157d001689a907e3e033L112-R245) [[5]](diffhunk://#diff-2edacf992c2069bb9ce56acd7e71a36a31f2c4b44322157d001689a907e3e033R272-R290) [[6]](diffhunk://#diff-eb62326137b9429973f117b044dfffd5ab658205176c5cc5721b74e8a61eed9aR11-R17) [[7]](diffhunk://#diff-eb62326137b9429973f117b044dfffd5ab658205176c5cc5721b74e8a61eed9aR124-R238) [[8]](diffhunk://#diff-eb62326137b9429973f117b044dfffd5ab658205176c5cc5721b74e8a61eed9aR288-R297)
* Updated the color scheme and styling for the palette, including responsive design for small screens and color adjustments for different VS Code themes. (`src/clihub/global.css`) [[1]](diffhunk://#diff-eb62326137b9429973f117b044dfffd5ab658205176c5cc5721b74e8a61eed9aR11-R17) [[2]](diffhunk://#diff-eb62326137b9429973f117b044dfffd5ab658205176c5cc5721b74e8a61eed9aR124-R238) [[3]](diffhunk://#diff-eb62326137b9429973f117b044dfffd5ab658205176c5cc5721b74e8a61eed9aR288-R297)

**Backend: Agent Data and Asset Management**

* Refactored the backend to define a new `LauncherAgent` type and generate a JSON list of agents (with icon, theme info, and installation status) injected into the frontend. (`src/clihub/main.ts`) [[1]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4R15-R52) [[2]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4L32-R62) [[3]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4L50-R80) [[4]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4L77-R138)
* Added a utility to check if each CLI agent is installed and expose this status to the frontend. (`src/clihub/webview/core/terminal-cli/installation.ts`, `src/clihub/main.ts`) [[1]](diffhunk://#diff-817d6129236290960c571582a8170dba6390a499d8f0fc1cbd3024b0bd0d50daR40-R45) [[2]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4L5-R6) [[3]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4L77-R138)
* Improved asset copying to include agent icons and support SVG files in the build/watch scripts. (`esbuild.js`) [[1]](diffhunk://#diff-4b2ed47327851d566740a30ce5f60271c059ae67eff2006bc07bb7c4fcee8b50R54) [[2]](diffhunk://#diff-4b2ed47327851d566740a30ce5f60271c059ae67eff2006bc07bb7c4fcee8b50L75-R76)

These changes collectively provide a more intuitive, visually rich, and accessible way for users to browse and launch CLI agents in the hub.