### PR TITLE
🛠️ Enhance file mention interactions and improve agent session handling

### DIFF
--- a/src/clihub/main.ts
+++ b/src/clihub/main.ts
@@ -9,10 +9,17 @@ import { getCliHubWebviewHtml } from './webview/webview';
 import { translatePromptToEnglish } from './webview/core/tools-cli-core/modal-translation/host-prompt-translator';
 import { preparePromptForCLI } from './webview/core/tools-cli-core/prompt/attachments/host-preparer';
 import type { ImageAttachment } from './webview/core/tools-cli-core/prompt';
+import {
+	getAgentLaunchGuardMessage,
+	type AgentLaunchExtensionMode,
+	type AgentLaunchGuardMessage,
+	type AgentLaunchSource
+} from './webview/ui/panel-terminal/agent-safety/agent-launch-guard';
 
 type CliHubMessage = {
 	type?: string;
 	agent?: string;
+	launchGuard?: AgentLaunchGuardMessage;
 	id?: string;
 	text?: string;
 	from?: string;
@@ -79,7 +86,15 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 		webviewView.webview.onDidReceiveMessage(async (message: CliHubMessage) => {
 			if (message.type === 'openAgent' && message.agent && allowedAgents.has(message.agent)) {
 				const agent = getCliAgent(message.agent);
-				if (!agent || !(await ensureCliInstalled(agent))) {
+				if (!agent) {
+					return;
+				}
+
+				if (!(await this._confirmAgentLaunch(message.agent, 'launcher'))) {
+					return;
+				}
+
+				if (!(await ensureCliInstalled(agent))) {
 					return;
 				}
 
@@ -116,6 +131,12 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 				return;
 			}
 
+			if (message.type === 'cli.create' && message.agent && allowedAgents.has(message.agent)) {
+				if (!(await this._confirmAgentLaunch(message.agent, 'panel'))) {
+					return;
+				}
+			}
+
 			if (message.type?.startsWith('cli.')) {
 				const result = this.sessionManager.handleMessage(message);
 				if (result === 'closed-last-session') {
@@ -129,6 +150,39 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 	public dispose() {
 		this.activePromptTranslation?.abort();
 		this.sessionManager.dispose();
+	}
+
+	private _getAgentLaunchExtensionMode(): AgentLaunchExtensionMode {
+		if (this._extensionContext?.extensionMode === vscode.ExtensionMode.Development) {
+			return 'development';
+		}
+		if (this._extensionContext?.extensionMode === vscode.ExtensionMode.Test) {
+			return 'test';
+		}
+		if (this._extensionContext?.extensionMode === vscode.ExtensionMode.Production) {
+			return 'production';
+		}
+
+		return 'unknown';
+	}
+
+	private async _confirmAgentLaunch(agentLabel: string, source: AgentLaunchSource) {
+		const guard = getAgentLaunchGuardMessage(agentLabel, {
+			source,
+			extensionMode: this._getAgentLaunchExtensionMode()
+		});
+		if (!guard) {
+			return true;
+		}
+
+		const choice = await vscode.window.showWarningMessage(
+			guard.message,
+			{ modal: true, detail: guard.detail },
+			guard.confirmLabel,
+			guard.cancelLabel
+		);
+
+		return choice === guard.confirmLabel;
 	}
 
 	private async _handleWorkspaceListFiles(webview: vscode.Webview, message: CliHubMessage) {

--- a/src/clihub/webview/ui/panel-terminal/agent-safety/agent-launch-guard.ts
+++ b/src/clihub/webview/ui/panel-terminal/agent-safety/agent-launch-guard.ts
@@ -1,0 +1,72 @@
+export type AgentLaunchSource = 'launcher' | 'panel';
+export type AgentLaunchExtensionMode = 'development' | 'production' | 'test' | 'unknown';
+
+export type AgentLaunchGuardContext = {
+	source: AgentLaunchSource;
+	extensionMode: AgentLaunchExtensionMode;
+};
+
+export type AgentLaunchGuardMessage = {
+	id: string;
+	agentLabel: string;
+	confirmLabel: string;
+	cancelLabel: string;
+	message: string;
+	detail: string;
+};
+
+type AgentLaunchGuardPolicy = {
+	id: string;
+	matches: (agentLabel: string) => boolean;
+	createMessage: (agentLabel: string, context: AgentLaunchGuardContext) => AgentLaunchGuardMessage;
+};
+
+const isCodexAgent = (agentLabel: string) => {
+	return agentLabel.toLowerCase().includes('codex');
+};
+
+const createCodexDetail = (context: AgentLaunchGuardContext) => {
+	if (context.extensionMode === 'development') {
+		return 'F1 is running in an Extension Development Host. If Codex is already open in your main IDE or terminal, opening another Codex CLI can interrupt or force re-authentication in the active session.';
+	}
+
+	if (context.source === 'launcher') {
+		return 'If Codex is already open in another terminal or IDE, opening it from F1 can interrupt or force re-authentication in that active session.';
+	}
+
+	return 'Codex sessions share account state outside F1. Opening another interactive Codex can interrupt an active Codex session elsewhere.';
+};
+
+const agentLaunchGuardPolicies: AgentLaunchGuardPolicy[] = [
+	{
+		id: 'codex-interactive-session',
+		matches: isCodexAgent,
+		createMessage: (agentLabel, context) => ({
+			id: 'codex-interactive-session',
+			agentLabel,
+			confirmLabel: 'Open Codex',
+			cancelLabel: 'Cancel',
+			message: 'Open Codex CLI?',
+			detail: createCodexDetail(context)
+		})
+	}
+];
+
+export const getAgentLaunchGuardMessage = (
+	agentLabel: string,
+	context: AgentLaunchGuardContext
+) => {
+	const policy = agentLaunchGuardPolicies.find((entry) => entry.matches(agentLabel));
+	return policy?.createMessage(agentLabel, context);
+};
+
+export const createCliCreateMessage = (
+	agentLabel: string,
+	context: AgentLaunchGuardContext
+) => {
+	return {
+		type: 'cli.create' as const,
+		agent: agentLabel,
+		launchGuard: getAgentLaunchGuardMessage(agentLabel, context)
+	};
+};

--- a/src/clihub/webview/ui/panel-terminal/terminal.ts
+++ b/src/clihub/webview/ui/panel-terminal/terminal.ts
@@ -1,6 +1,7 @@
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import { createTabController, type CliAgentIcon, type CliAgentOption, type CliSessionSummary } from '../panel-tab/tab';
+import { createCliCreateMessage, type AgentLaunchGuardMessage } from './agent-safety/agent-launch-guard';
 import { createToolsController } from './tools-cli-ui/tools';
 import type { ImageAttachment, PromptTranslateRequest, PromptTranslateResult, FileMentionEntry } from '../../core/tools-cli-core/prompt';
 
@@ -10,7 +11,7 @@ type VsCodeApi = {
 
 type ClientMessage =
 	| { type: 'cli.ready' }
-	| { type: 'cli.create'; agent: string }
+	| { type: 'cli.create'; agent: string; launchGuard?: AgentLaunchGuardMessage }
 	| { type: 'cli.input'; sessionId: string; data: string }
 	| { type: 'cli.switch'; sessionId: string }
 	| { type: 'cli.resize'; sessionId?: string; cols: number; rows: number }
@@ -336,7 +337,10 @@ const toolsController = layoutRight
 
 const tabController = createTabController({
 	getAgentIcon: (label) => agentIcons.get(label),
-	onCreate: (agent) => vscode.postMessage({ type: 'cli.create', agent }),
+	onCreate: (agent) => vscode.postMessage(createCliCreateMessage(agent, {
+		source: 'panel',
+		extensionMode: 'unknown'
+	})),
 	onCycleSession: (offset) => {
 		switchSessionByOffset(offset);
 	},

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/file-mention/file-mention.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/file-mention/file-mention.ts
@@ -223,7 +223,56 @@ export function mountFileMentionPicker(
 
 	// ── Textarea listeners ───────────────────────────────────────────
 
+	/**
+	 * Ctrl+Backspace while the caret is right after an @mention:
+	 * deletes everything between '@' and the caret, leaving '@' so
+	 * the user can type a new path without closing the modal.
+	 * Returns true if it handled the event (caller should return early).
+	 */
+	const handleMentionCtrlBackspace = (e: KeyboardEvent): boolean => {
+		if (!e.ctrlKey || e.key !== 'Backspace') { return false; }
+
+		const caret = textarea.selectionStart ?? 0;
+		const selEnd = textarea.selectionEnd ?? 0;
+
+		// Only act when nothing is selected and caret is not at the very start
+		if (caret !== selEnd || caret === 0) { return false; }
+
+		const value = textarea.value;
+
+		// Scan backwards from caret looking for a bare '@' trigger.
+		// We stop as soon as we hit whitespace (we've left the mention token).
+		let atPos = -1;
+		for (let i = caret - 1; i >= 0; i--) {
+			const ch = value[i];
+			if (ch === '@') {
+				// Valid trigger: at start-of-string OR preceded by whitespace
+				if (i === 0 || /\s/.test(value[i - 1])) {
+					atPos = i;
+				}
+				break;
+			}
+			if (/\s/.test(ch)) { break; } // left the token, stop
+		}
+
+		if (atPos === -1) { return false; }
+
+		// Delete from the char right after '@' up to the caret → leaves '@'
+		e.preventDefault();
+		e.stopPropagation();
+		const newValue = value.slice(0, atPos + 1) + value.slice(caret);
+		textarea.value = newValue;
+		const newPos = atPos + 1;
+		textarea.setSelectionRange(newPos, newPos);
+		textarea.dispatchEvent(new Event('input', { bubbles: true }));
+		return true;
+	};
+
 	textarea.addEventListener('keydown', (e) => {
+		// Ctrl+Backspace on an @mention → erase the path, keep '@'
+		// Must run BEFORE the dropdown guard so it works even when dropdown is closed.
+		if (handleMentionCtrlBackspace(e)) { return; }
+
 		if (!dropdown) { return; }
 		if (e.key === 'ArrowDown') { e.preventDefault(); activeIndex = Math.min(activeIndex + 1, entries.length - 1); updateActive(); }
 		if (e.key === 'ArrowUp')   { e.preventDefault(); activeIndex = Math.max(activeIndex - 1, 0); updateActive(); }

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/file-mention/file-mention.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/file-mention/file-mention.ts
@@ -240,10 +240,19 @@ export function mountFileMentionPicker(
 
 		const value = textarea.value;
 
-		// Scan backwards from caret looking for a bare '@' trigger.
-		// We stop as soon as we hit whitespace (we've left the mention token).
+		// selectEntry appends a trailing space after the path ("@path ").
+		// If the caret is sitting right after that space, skip it before scanning
+		// so the backwards walk reaches '@' in one Ctrl+Backspace press.
+		// We also extend the delete range to consume that trailing space.
+		let scanFrom = caret;
+		if (scanFrom > 0 && value[scanFrom - 1] === ' ') {
+			scanFrom -= 1;
+		}
+
+		// Scan backwards looking for a bare '@' trigger.
+		// Stop at any whitespace that isn't the one space we already skipped.
 		let atPos = -1;
-		for (let i = caret - 1; i >= 0; i--) {
+		for (let i = scanFrom - 1; i >= 0; i--) {
 			const ch = value[i];
 			if (ch === '@') {
 				// Valid trigger: at start-of-string OR preceded by whitespace
@@ -257,7 +266,8 @@ export function mountFileMentionPicker(
 
 		if (atPos === -1) { return false; }
 
-		// Delete from the char right after '@' up to the caret → leaves '@'
+		// Delete from the char right after '@' up to the original caret
+		// (includes the trailing space when present) → leaves a clean '@'
 		e.preventDefault();
 		e.stopPropagation();
 		const newValue = value.slice(0, atPos + 1) + value.slice(caret);

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/file-mention/file-mention.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/file-mention/file-mention.ts
@@ -229,7 +229,7 @@ export function mountFileMentionPicker(
 		if (e.key === 'ArrowUp')   { e.preventDefault(); activeIndex = Math.max(activeIndex - 1, 0); updateActive(); }
 		if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { /* let send shortcut handle */ return; }
 		if (e.key === 'Enter')  { e.preventDefault(); if (entries[activeIndex]) { selectEntry(entries[activeIndex]); } }
-		if (e.key === 'Escape') { closeDropdown(); }
+		if (e.key === 'Escape') { e.stopPropagation(); closeDropdown(); }
 		if (e.key === 'Tab')    { e.preventDefault(); if (entries[activeIndex]) { selectEntry(entries[activeIndex]); } }
 	});
 

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/file-mention/file-mention.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/file-mention/file-mention.ts
@@ -82,14 +82,28 @@ export function mountFileMentionPicker(
 		const list = dropdown.querySelector<HTMLElement>('.fm-list');
 		if (!list) { return; }
 
-		// folders first, then files; filtered by name OR path (better discoverability)
+		// Relevance-first sort: name starts-with query > name contains query > path contains query.
+		// Within each tier: directories before files, then alphabetical.
 		const lc = filter.toLowerCase();
+
+		/** 0 = name starts with query (best), 1 = name contains query, 2 = only path matches */
+		const relevance = (e: FileMentionEntry): number => {
+			const nameLc = e.name.toLowerCase();
+			if (nameLc.startsWith(lc)) { return 0; }
+			if (nameLc.includes(lc))   { return 1; }
+			return 2;
+		};
+
 		const filtered = items
 			.filter(e => {
 				const haystack = `${e.name} ${e.path}`.toLowerCase();
 				return haystack.includes(lc);
 			})
 			.sort((a, b) => {
+				const ra = relevance(a);
+				const rb = relevance(b);
+				if (ra !== rb) { return ra - rb; }
+				// Within same relevance tier: directories first, then alphabetical
 				if (a.isDirectory !== b.isDirectory) { return a.isDirectory ? -1 : 1; }
 				return a.name.localeCompare(b.name);
 			});

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
@@ -359,6 +359,17 @@
   color: var(--vscode-input-foreground);
 }
 
+/* @file-mention tokens — blue, matching VS Code link / variable colour */
+.prompt-textarea-highlight .prompt-mention {
+  color: var(--vscode-textLink-foreground, #58a6ff);
+  font-weight: 500;
+}
+
+/* When a mention is (partially) selected, the selection colour wins */
+.prompt-textarea-highlight .selected .prompt-mention {
+  color: inherit !important;
+}
+
 .prompt-char-count {
   position: absolute;
   bottom: 10px;

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
@@ -727,6 +727,8 @@ function updatePromptImageHighlight(
   highlight.scrollLeft = textarea.scrollLeft;
 }
 
+type TokenKind = 'image' | 'mention' | 'plain';
+
 function buildPromptHighlightNodes(text: string, selStart: number = -1, selEnd: number = -1): Node[] {
   if (!text) {
     return [];
@@ -734,34 +736,43 @@ function buildPromptHighlightNodes(text: string, selStart: number = -1, selEnd: 
 
   const nodes: Node[] = [];
   let lastIndex = 0;
-
   const hasSel = selStart >= 0 && selEnd > selStart;
 
-  const markerMatches = Array.from(text.matchAll(/\[Image #(\d+)\]/g));
+  // Collect all special tokens (image markers + @file mentions) sorted by position.
+  type Token = { start: number; end: number; kind: TokenKind };
+  const tokens: Token[] = [];
 
-  for (const match of markerMatches) {
-    const mStart = match.index ?? 0;
-    const mEnd = mStart + match[0].length;
+  for (const match of text.matchAll(/\[Image #(\d+)\]/g)) {
+    tokens.push({ start: match.index ?? 0, end: (match.index ?? 0) + match[0].length, kind: 'image' });
+  }
+  // @mention: '@' followed by any non-whitespace chars (file paths inserted by the picker)
+  for (const match of text.matchAll(/@\S+/g)) {
+    tokens.push({ start: match.index ?? 0, end: (match.index ?? 0) + match[0].length, kind: 'mention' });
+  }
+  tokens.sort((a, b) => a.start - b.start);
 
-    // plain text before this marker
-    if (mStart > lastIndex) {
-      appendSegment(nodes, text, lastIndex, mStart, selStart, selEnd, hasSel, false);
+  for (const token of tokens) {
+    // Guard against overlapping tokens (should not happen in practice)
+    if (token.start < lastIndex) { continue; }
+
+    // plain text before this token
+    if (token.start > lastIndex) {
+      appendSegment(nodes, text, lastIndex, token.start, selStart, selEnd, hasSel, 'plain');
     }
-
-    // the marker token
-    appendSegment(nodes, text, mStart, mEnd, selStart, selEnd, hasSel, true);
-
-    lastIndex = mEnd;
+    // the token itself
+    appendSegment(nodes, text, token.start, token.end, selStart, selEnd, hasSel, token.kind);
+    lastIndex = token.end;
   }
 
   // trailing plain text
   if (lastIndex < text.length) {
-    appendSegment(nodes, text, lastIndex, text.length, selStart, selEnd, hasSel, false);
+    appendSegment(nodes, text, lastIndex, text.length, selStart, selEnd, hasSel, 'plain');
   }
 
   return nodes;
 }
 
+/** Append one text segment to the node list, honouring selection overlap. */
 function appendSegment(
   nodes: Node[],
   fullText: string,
@@ -770,80 +781,46 @@ function appendSegment(
   selStart: number,
   selEnd: number,
   hasSel: boolean,
-  isMarker: boolean
+  kind: TokenKind
 ) {
-  if (from >= to) {
-    return;
-  }
+  if (from >= to) { return; }
+
+  const cssClass = kind === 'image' ? 'prompt-image-marker'
+                 : kind === 'mention' ? 'prompt-mention'
+                 : 'plain';
+
+  const makeSpan = (content: string, cls: string): HTMLSpanElement => {
+    const s = document.createElement('span');
+    s.className = cls;
+    s.textContent = content;
+    return s;
+  };
 
   const segmentText = fullText.slice(from, to);
 
   if (!hasSel || to <= selStart || from >= selEnd) {
-    // no selection overlap
-    if (isMarker) {
-      const span = document.createElement('span');
-      span.className = 'prompt-image-marker';
-      span.textContent = segmentText;
-      nodes.push(span);
-    } else {
-      const span = document.createElement('span');
-      span.className = 'plain';
-      span.textContent = segmentText;
-      nodes.push(span);
-    }
+    // No selection overlap — simple case
+    nodes.push(makeSpan(segmentText, cssClass));
     return;
   }
 
-  // overlaps selection: split into before / selected / after
+  // Overlaps selection: split into before / selected / after
   const selFrom = Math.max(from, selStart);
-  const selTo = Math.min(to, selEnd);
+  const selTo   = Math.min(to,   selEnd);
 
   if (from < selFrom) {
-    const before = fullText.slice(from, selFrom);
-    if (isMarker) {
-      const span = document.createElement('span');
-      span.className = 'prompt-image-marker';
-      span.textContent = before;
-      nodes.push(span);
-    } else {
-      const span = document.createElement('span');
-      span.className = 'plain';
-      span.textContent = before;
-      nodes.push(span);
-    }
+    nodes.push(makeSpan(fullText.slice(from, selFrom), cssClass));
   }
 
   if (selFrom < selTo) {
-    const selectedText = fullText.slice(selFrom, selTo);
     const selSpan = document.createElement('span');
     selSpan.className = 'selected';
-    if (isMarker) {
-      // wrap marker content so badge can be overridden by .selected
-      const markerSpan = document.createElement('span');
-      markerSpan.className = 'prompt-image-marker';
-      markerSpan.textContent = selectedText;
-      selSpan.appendChild(markerSpan);
-    } else {
-      const plainSel = document.createElement('span');
-      plainSel.className = 'plain';
-      plainSel.textContent = selectedText;
-      selSpan.appendChild(plainSel);
-    }
+    // Nest the token span inside .selected so the badge/colour can be overridden
+    selSpan.appendChild(makeSpan(fullText.slice(selFrom, selTo), cssClass));
     nodes.push(selSpan);
   }
 
   if (selTo < to) {
-    const after = fullText.slice(selTo, to);
-    if (isMarker) {
-      const span = document.createElement('span');
-      span.className = 'prompt-image-marker';
-      span.textContent = after;
-      nodes.push(span);
-    } else {
-      const span = document.createElement('span');
-      span.className = 'plain';
-      span.textContent = after;
-      nodes.push(span);
-    }
+    nodes.push(makeSpan(fullText.slice(selTo, to), cssClass));
   }
 }

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
@@ -693,7 +693,10 @@ function setupImagePaste(
 			.filter((part) => part && part.trim().length > 0)
 			.join(textWithMarkers && imageMarkers.length ? ' ' : '');
 
-		insertTextAtSelection(textarea, insertValue);
+		// Add a trailing space when the insert ends with an image marker so the
+		// cursor lands right after the token ready to type — same as @path mentions.
+		const insertWithSpacing = insertValue.endsWith(']') ? insertValue + ' ' : insertValue;
+		insertTextAtSelection(textarea, insertWithSpacing);
 	});
 }
 


### PR DESCRIPTION
This pull request introduces an agent launch safety guard for Codex CLI sessions and improves the UX for file mentions and image markers in the CLI prompt UI. The main changes add a confirmation dialog to prevent accidental Codex session interruptions, enhance the discoverability and usability of file mentions, and visually distinguish special tokens in the prompt textarea.

**Agent launch safety and confirmation:**

* Added an agent launch guard system to warn users before opening Codex CLI sessions, preventing accidental session interruptions or forced re-authentication. This includes context-aware confirmation dialogs based on launch source and extension mode. (`src/clihub/main.ts`, `src/clihub/webview/ui/panel-terminal/agent-safety/agent-launch-guard.ts`) [[1]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4R12-R22) [[2]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4L82-R97) [[3]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4R134-R139) [[4]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4R155-R187) [[5]](diffhunk://#diff-e3f44869f4c32ef86b037580b6c8a23d1ccab51ea98e3c7809c1421662125d83R1-R72)
* Updated the webview messaging protocol to include optional `launchGuard` messages when creating CLI sessions, and ensured the panel properly posts these messages. (`src/clihub/webview/ui/panel-terminal/terminal.ts`) [[1]](diffhunk://#diff-74bfb6e2f596b2e5f1d929921f430dc772c7ba9812da85417fb2067c582e06cdR4) [[2]](diffhunk://#diff-74bfb6e2f596b2e5f1d929921f430dc772c7ba9812da85417fb2067c582e06cdL13-R14) [[3]](diffhunk://#diff-74bfb6e2f596b2e5f1d929921f430dc772c7ba9812da85417fb2067c582e06cdL339-R343)

**File mention and prompt UX improvements:**

* Improved file mention picker sorting to prioritize name matches and directories, making it easier to find relevant files. (`src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/file-mention/file-mention.ts`)
* Added a keyboard shortcut (Ctrl+Backspace) to quickly erase a file mention path, leaving the `@` trigger for fast re-entry. (`src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/file-mention/file-mention.ts`)
* Enhanced prompt textarea highlighting to visually distinguish file mentions (`@path`) and image markers, using VS Code theme colours. (`src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts`, `src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css`) [[1]](diffhunk://#diff-4de9b4566fbbfeadb336115f0c5645afa244230a1e92db9235d566a4c834e09aL696-R699) [[2]](diffhunk://#diff-4de9b4566fbbfeadb336115f0c5645afa244230a1e92db9235d566a4c834e09aR733-R778) [[3]](diffhunk://#diff-4de9b4566fbbfeadb336115f0c5645afa244230a1e92db9235d566a4c834e09aL773-R827) [[4]](diffhunk://#diff-ebdae3cbe65f7fb561f33b146f2bcacd5f79777aa89c0a48c63f9636c4e8b194R362-R372)
* Ensured pasted image markers insert a trailing space, matching the behaviour of file mentions for improved typing flow. (`src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts`)

These changes collectively improve the safety, usability, and clarity of the CLI panel, especially when working with Codex sessions and composing prompts with file mentions or images.