### PR TITLE
🛠️ Enhance skill discovery and improve prompt modal styling

### DIFF
--- a/src/clihub/main.ts
+++ b/src/clihub/main.ts
@@ -139,6 +139,11 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 				return;
 			}
 
+			if (message.type === 'workspace.listSkills') {
+				await this._handleWorkspaceListSkills(webviewView.webview, message);
+				return;
+			}
+
 			if (message.type === 'cli.create' && message.agent && allowedAgents.has(message.agent)) {
 				if (!(await this._confirmAgentLaunch(message.agent, 'panel'))) {
 					return;
@@ -191,6 +196,54 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 		);
 
 		return choice === guard.confirmLabel;
+	}
+
+	private async _handleWorkspaceListSkills(webview: vscode.Webview, message: CliHubMessage) {
+		if (typeof message.id !== 'string') {
+			return;
+		}
+
+		// A skill is a directory under one of these roots containing a SKILL.md.
+		// Only the folder name is surfaced; .agents takes precedence on duplicates.
+		const skillRoots = ['.agents/skills', '.claude/skills'];
+		const names = new Set<string>();
+		const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+
+		if (workspaceFolder) {
+			for (const root of skillRoots) {
+				const rootUri = vscode.Uri.joinPath(workspaceFolder.uri, ...root.split('/'));
+				let entries: Array<[string, vscode.FileType]>;
+				try {
+					entries = await vscode.workspace.fs.readDirectory(rootUri);
+				} catch {
+					continue; // root doesn't exist — normal
+				}
+
+				const checks = entries
+					.filter(([name, type]) => type === vscode.FileType.Directory && !name.startsWith('.'))
+					.map(async ([name]) => {
+						try {
+							const manifest = vscode.Uri.joinPath(rootUri, name, 'SKILL.md');
+							const stat = await vscode.workspace.fs.stat(manifest);
+							return stat.type === vscode.FileType.File ? name : undefined;
+						} catch {
+							return undefined;
+						}
+					});
+
+				for (const name of await Promise.all(checks)) {
+					if (name) {
+						names.add(name);
+					}
+				}
+			}
+		}
+
+		await webview.postMessage({
+			type: 'workspace.skills',
+			id: message.id,
+			skills: [...names].sort(),
+		});
 	}
 
 	private async _handleWorkspaceListFiles(webview: vscode.Webview, message: CliHubMessage) {

--- a/src/clihub/webview/ui/panel-tab/tab.css
+++ b/src/clihub/webview/ui/panel-tab/tab.css
@@ -461,7 +461,7 @@
 	bottom: 14px;
 	z-index: 2000;
 	max-width: calc(100vw - 28px);
-	padding: 7px 10px;
+	padding: 4px 12px;
 	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.28));
 	border-radius: 6px;
 	box-sizing: border-box;
@@ -481,6 +481,20 @@
 .agent-tools-toast.is-visible {
 	opacity: 1;
 	transform: translate(-50%, 0);
+}
+
+.agent-tools-toast.is-enabled {
+	color: #10b981;
+	background: color-mix(in srgb, #10b981 15%, var(--vscode-editor-background, #1e1e1e));
+	border-color: #10b981;
+	box-shadow: 0 0 10px color-mix(in srgb, #10b981 30%, transparent), 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.agent-tools-toast.is-disabled {
+	color: #ef4444;
+	background: color-mix(in srgb, #ef4444 15%, var(--vscode-editor-background, #1e1e1e));
+	border-color: #ef4444;
+	box-shadow: 0 0 10px color-mix(in srgb, #ef4444 30%, transparent), 0 8px 24px rgba(0, 0, 0, 0.4);
 }
 
 .agent-session-list {

--- a/src/clihub/webview/ui/panel-tab/tab.ts
+++ b/src/clihub/webview/ui/panel-tab/tab.ts
@@ -142,7 +142,7 @@ export const createTabController = (options: TabControllerOptions) => {
 			document.body.append(toast);
 		}
 
-		toast.textContent = enabled ? 'Prompt filter enabled' : 'Prompt filter disabled';
+		toast.textContent = enabled ? 'Prompt filter enabled ✔' : 'Prompt filter disabled ✖';
 		toast.classList.toggle('is-enabled', enabled);
 		toast.classList.toggle('is-disabled', !enabled);
 		toast.classList.add('is-visible');

--- a/src/clihub/webview/ui/panel-tab/tab.ts
+++ b/src/clihub/webview/ui/panel-tab/tab.ts
@@ -142,7 +142,9 @@ export const createTabController = (options: TabControllerOptions) => {
 			document.body.append(toast);
 		}
 
-		toast.textContent = enabled ? 'Prompt filter enabled ✅' : 'Prompt filter disabled ❌';
+		toast.textContent = enabled ? 'Prompt filter enabled' : 'Prompt filter disabled';
+		toast.classList.toggle('is-enabled', enabled);
+		toast.classList.toggle('is-disabled', !enabled);
 		toast.classList.add('is-visible');
 
 		promptFilterToastTimer = window.setTimeout(() => {

--- a/src/clihub/webview/ui/panel-terminal/terminal.ts
+++ b/src/clihub/webview/ui/panel-terminal/terminal.ts
@@ -20,7 +20,8 @@ type ClientMessage =
 	| { type: 'prompt.translate'; id: string; text: string; from: string; to: string }
 	| { type: 'prompt.prepare'; id: string; text: string; attachments: ImageAttachment[] }
 	| { type: 'prompt.spellcheck'; id: string; text: string; strict: boolean }
-	| { type: 'workspace.listFiles'; id: string };
+	| { type: 'workspace.listFiles'; id: string }
+	| { type: 'workspace.listSkills'; id: string };
 
 type CliSession = CliSessionSummary & {
 	commandLine: string;
@@ -42,7 +43,8 @@ type ServerMessage =
 	| { type: 'prompt.prepared'; id: string; text: string }
 	| { type: 'prompt.prepareError'; id: string; message: string }
 	| { type: 'prompt.spellResult'; id: string; issues: SpellIssue[] }
-	| { type: 'workspace.files'; id: string; files: FileMentionEntry[] };
+	| { type: 'workspace.files'; id: string; files: FileMentionEntry[] }
+	| { type: 'workspace.skills'; id: string; skills: string[] };
 
 type TerminalView = {
 	terminal: Terminal;
@@ -274,6 +276,24 @@ const requestWorkspaceFiles = (): Promise<FileMentionEntry[]> => {
 	});
 };
 
+const pendingWorkspaceSkills = new Map<string, (skills: string[]) => void>();
+let nextWorkspaceSkillsId = 1;
+
+const requestWorkspaceSkills = (): Promise<string[]> => {
+	const id = `ws-skills-${nextWorkspaceSkillsId++}`;
+	return new Promise((resolve) => {
+		const timeout = window.setTimeout(() => {
+			pendingWorkspaceSkills.delete(id);
+			resolve([]);
+		}, 5000);
+		pendingWorkspaceSkills.set(id, (skills) => {
+			clearTimeout(timeout);
+			resolve(skills);
+		});
+		vscode.postMessage({ type: 'workspace.listSkills', id });
+	});
+};
+
 const pendingSpellchecks = new Map<string, (issues: SpellIssue[]) => void>();
 let nextSpellcheckId = 1;
 
@@ -381,6 +401,7 @@ const toolsController = layoutRight
 			translatePrompt,
 			preparePromptWithAttachments,
 			requestWorkspaceFiles,
+			requestWorkspaceSkills,
 			requestSpellcheck,
 			getTerminalSelection: () => {
 				if (!activeSessionId) {
@@ -955,6 +976,15 @@ window.addEventListener('message', (event: MessageEvent<ServerMessage>) => {
 		if (handler) {
 			pendingWorkspaceFiles.delete(message.id);
 			handler(message.files);
+		}
+		return;
+	}
+
+	if (message.type === 'workspace.skills') {
+		const handler = pendingWorkspaceSkills.get(message.id);
+		if (handler) {
+			pendingWorkspaceSkills.delete(message.id);
+			handler(message.skills);
 		}
 		return;
 	}

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
@@ -980,7 +980,7 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 8px 16px;
+  padding: 8px 20px 8px 14px;
   background: rgba(83, 74, 183, 0.85);
   border: none;
   border-radius: 7px;

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
@@ -661,6 +661,32 @@
   flex-wrap: wrap;
 }
 
+/* display:flex above would defeat the hidden attribute's UA display:none */
+.prompt-skills[hidden] {
+  display: none;
+}
+
+/* Empty state: inert dashed "+" placeholder, tinted with the CLI accent.
+   TODO(future): becomes the entry point of the skill install/create flow. */
+.prompt-skill-add {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--agent-accent, #534AB7) 45%, transparent);
+  color: var(--agent-accent, #AFA9EC);
+  background: color-mix(in srgb, var(--agent-accent, #534AB7) 6%, transparent);
+  min-width: 30px;
+  font-size: 13px;
+  line-height: 1;
+  cursor: default;
+}
+
+.prompt-skill-add:hover {
+  /* Inert for now — keep the resting look, no interactive affordance */
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--agent-accent, #534AB7) 45%, transparent);
+  color: var(--agent-accent, #AFA9EC);
+  background: color-mix(in srgb, var(--agent-accent, #534AB7) 6%, transparent);
+}
+
 .prompt-skills-label {
   font-size: 11px;
   font-weight: 600;

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
@@ -667,24 +667,22 @@
 }
 
 /* Empty state: inert dashed "+" placeholder, tinted with the CLI accent.
+   The base chip's 0.5px border renders dashes invisibly — this needs a full
+   1px dashed border to show the dots at rest, plus a squarer shape.
    TODO(future): becomes the entry point of the skill install/create flow. */
-.prompt-skill-add {
-  border-style: dashed;
-  border-color: color-mix(in srgb, var(--agent-accent, #534AB7) 45%, transparent);
+.prompt-skill-add,
+.prompt-skill-add:hover {
+  border: 1px dashed color-mix(in srgb, var(--agent-accent, #534AB7) 65%, transparent);
+  border-radius: 4px;
   color: var(--agent-accent, #AFA9EC);
   background: color-mix(in srgb, var(--agent-accent, #534AB7) 6%, transparent);
-  min-width: 30px;
-  font-size: 13px;
+  width: 28px;
+  height: 26px;
+  padding: 0;
+  justify-content: center;
+  font-size: 14px;
   line-height: 1;
   cursor: default;
-}
-
-.prompt-skill-add:hover {
-  /* Inert for now — keep the resting look, no interactive affordance */
-  border-style: dashed;
-  border-color: color-mix(in srgb, var(--agent-accent, #534AB7) 45%, transparent);
-  color: var(--agent-accent, #AFA9EC);
-  background: color-mix(in srgb, var(--agent-accent, #534AB7) 6%, transparent);
 }
 
 .prompt-skills-label {

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.html
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.html
@@ -54,15 +54,11 @@
       ></textarea>
       <span class="prompt-char-count" id="charCount">0/1500</span>
     </div>
-    <div class="prompt-skills">
+    <!-- Chips are populated at mount with the skills installed in the
+         workspace (.agents/skills + .claude/skills); hidden when none. -->
+    <div class="prompt-skills" hidden>
       <span class="prompt-skills-label">Skills:</span>
-      <div class="prompt-tools">
-        <button class="prompt-tool-btn" data-skill="skill-1">Skill 1</button>
-        <button class="prompt-tool-btn" data-skill="skill-2">Skill 2</button>
-        <button class="prompt-tool-btn" data-skill="skill-3">Skill 3</button>
-        <button class="prompt-tool-btn" data-skill="skill-4">Skill 4</button>
-        <button class="prompt-tool-btn" data-skill="skill-5">Skill 5</button>
-      </div>
+      <div class="prompt-tools" id="skillChips"></div>
     </div>
   </div>
   <!-- DIVIDER -->

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
@@ -69,6 +69,7 @@ type PromptContext = {
 	translatePrompt?: (request: PromptTranslateRequest) => Promise<PromptTranslateResult>;
 	preparePromptWithAttachments?: (text: string, attachments: ImageAttachment[]) => Promise<string>;
 	requestWorkspaceFiles?: () => Promise<FileMentionEntry[]>;
+	requestWorkspaceSkills?: () => Promise<string[]>;
 	requestSpellcheck?: (text: string, strict: boolean) => Promise<SpellIssue[]>;
 };
 
@@ -299,6 +300,13 @@ function initPromptTabs(host: HTMLElement, context: PromptContext, hasActiveSess
 		// original verbatim content (never lowercased, never translated).
 		textToSend = expandPasteMarkers(textToSend, pasteAttachments);
 
+		// Selected skill chips ride along as an explicit instruction. Appended
+		// post-translation (already English) so it never hits the translator.
+		if (selectedSkills.size > 0) {
+			const names = [...selectedSkills].map((name) => `"${name}"`).join(', ');
+			textToSend += `\n\nUse the following skill${selectedSkills.size === 1 ? '' : 's'}: ${names}.`;
+		}
+
 		const result = processPrompt(textToSend, {
 			close: ctx.close,
 			sendToActiveSession: ctx.sendToActiveSession,
@@ -325,8 +333,11 @@ function initPromptTabs(host: HTMLElement, context: PromptContext, hasActiveSess
 		textarea.focus();
 	});
 
+	// Skills the user toggles on travel with the prompt as an explicit instruction.
+	const selectedSkills = new Set<string>();
+
 	if (hasActiveSession) {
-		initSkillsChips(host);
+		initSkillsChips(host, context, selectedSkills);
 		const tools = initToolbarActions(
 			host,
 			() => translateState.enabled,
@@ -568,16 +579,38 @@ function enforceLowercaseInput(textarea: HTMLTextAreaElement) {
 	});
 }
 
-function initSkillsChips(host: HTMLElement) {
-	const chips = host.querySelectorAll<HTMLButtonElement>('.prompt-tool-btn');
+// Populate the Skills row with the skills installed in the workspace
+// (.agents/skills/* and .claude/skills/*, folders containing a SKILL.md —
+// scanned host-side). The row only appears when at least one skill exists.
+function initSkillsChips(host: HTMLElement, context: PromptContext, selectedSkills: Set<string>) {
+	const row = host.querySelector<HTMLElement>('.prompt-skills');
+	const chipsHost = host.querySelector<HTMLElement>('#skillChips');
+	if (!row || !chipsHost || !context.requestWorkspaceSkills) {
+		return;
+	}
 
-	chips.forEach((chip) => {
-		chip.addEventListener('click', () => {
-					chip.classList.toggle('selected');
+	void context.requestWorkspaceSkills().then((skills) => {
+		if (!skills.length || !row.isConnected) {
+			return;
+		}
 
-			// Optional: if you want only one skill active at a time, uncomment below
-			// chips.forEach(c => c !== chip && c.classList.remove('selected'));
-		});
+		chipsHost.replaceChildren();
+		for (const name of skills) {
+			const chip = document.createElement('button');
+			chip.className = 'prompt-tool-btn';
+			chip.dataset.skill = name;
+			chip.textContent = name;
+			chip.title = `Ask the CLI to use its "${name}" skill`;
+			chip.addEventListener('click', () => {
+				if (chip.classList.toggle('selected')) {
+					selectedSkills.add(name);
+				} else {
+					selectedSkills.delete(name);
+				}
+			});
+			chipsHost.append(chip);
+		}
+		row.hidden = false;
 	});
 }
 

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
@@ -590,11 +590,25 @@ function initSkillsChips(host: HTMLElement, context: PromptContext, selectedSkil
 	}
 
 	void context.requestWorkspaceSkills().then((skills) => {
-		if (!skills.length || !row.isConnected) {
+		if (!row.isConnected) {
 			return;
 		}
 
 		chipsHost.replaceChildren();
+
+		// No skills installed: show an inert dashed "+" placeholder.
+		// TODO(future): wire this to a skill install/create flow after the refactor.
+		if (!skills.length) {
+			const addChip = document.createElement('button');
+			addChip.className = 'prompt-tool-btn prompt-skill-add';
+			addChip.textContent = '+';
+			addChip.title = 'Add skills — coming soon';
+			addChip.setAttribute('aria-disabled', 'true');
+			chipsHost.append(addChip);
+			row.hidden = false;
+			return;
+		}
+
 		for (const name of skills) {
 			const chip = document.createElement('button');
 			chip.className = 'prompt-tool-btn';

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/tools.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/tools.ts
@@ -14,6 +14,7 @@ export type ToolContext = {
 	getTerminalSelection?: () => string;
 	preparePromptWithAttachments?: (text: string, attachments: ImageAttachment[]) => Promise<string>;
 	requestWorkspaceFiles?: () => Promise<FileMentionEntry[]>;
+	requestWorkspaceSkills?: () => Promise<string[]>;
 	requestSpellcheck?: (text: string, strict: boolean) => Promise<SpellIssue[]>;
 };
 
@@ -27,6 +28,7 @@ export type ToolsControllerOptions = {
 	getTerminalSelection?: () => string;
 	preparePromptWithAttachments?: (text: string, attachments: ImageAttachment[]) => Promise<string>;
 	requestWorkspaceFiles?: () => Promise<FileMentionEntry[]>;
+	requestWorkspaceSkills?: () => Promise<string[]>;
 	requestSpellcheck?: (text: string, strict: boolean) => Promise<SpellIssue[]>;
 };
 
@@ -55,6 +57,7 @@ const toolMounts: Record<ToolId, ToolMount> = {
 		getTerminalSelection,
 		preparePromptWithAttachments,
 		requestWorkspaceFiles,
+		requestWorkspaceSkills,
 		requestSpellcheck
 	}: ToolsControllerOptions) => {
 		let activeModal: HTMLElement | null = null;
@@ -122,6 +125,7 @@ const toolMounts: Record<ToolId, ToolMount> = {
 					getTerminalSelection,
 					preparePromptWithAttachments,
 					requestWorkspaceFiles,
+					requestWorkspaceSkills,
 					requestSpellcheck
 				});
 


### PR DESCRIPTION
This pull request adds support for detecting and displaying "skills" installed in the workspace within the CLI Hub panel's prompt UI. Skills are discovered as folders containing a `SKILL.md` file under `.agents/skills` or `.claude/skills`, and users can now select these skills as chips when composing prompts. The system is fully integrated between the extension backend and the webview frontend, and includes UI/UX improvements for skill selection and prompt filtering.

**Workspace Skills Integration:**

* Added backend logic in `src/clihub/main.ts` to scan the workspace for installed skills (directories with `SKILL.md` under `.agents/skills` and `.claude/skills`), deduplicate them, and expose them to the webview via a new `workspace.listSkills` message type. [[1]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4R142-R146) [[2]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4R201-R248)
* Extended the webview messaging protocol in `src/clihub/webview/ui/panel-terminal/terminal.ts` to support requesting and receiving the workspace skills list, including promise-based request/response handling and timeouts. [[1]](diffhunk://#diff-74bfb6e2f596b2e5f1d929921f430dc772c7ba9812da85417fb2067c582e06cdL23-R24) [[2]](diffhunk://#diff-74bfb6e2f596b2e5f1d929921f430dc772c7ba9812da85417fb2067c582e06cdL45-R47) [[3]](diffhunk://#diff-74bfb6e2f596b2e5f1d929921f430dc772c7ba9812da85417fb2067c582e06cdR279-R296) [[4]](diffhunk://#diff-74bfb6e2f596b2e5f1d929921f430dc772c7ba9812da85417fb2067c582e06cdR404) [[5]](diffhunk://#diff-74bfb6e2f596b2e5f1d929921f430dc772c7ba9812da85417fb2067c582e06cdR983-R991)

**Prompt UI Enhancements:**

* Updated the prompt modal in `src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts` and its HTML/CSS to dynamically render skill chips based on the installed workspace skills, allow toggling selected skills, and append explicit skill usage instructions to the prompt text. [[1]](diffhunk://#diff-8703d7a80bf9a45ed7e955892dc2747daad874ec0ef8d5940fdc6fd47426bc81L57-R61) [[2]](diffhunk://#diff-4de9b4566fbbfeadb336115f0c5645afa244230a1e92db9235d566a4c834e09aR72) [[3]](diffhunk://#diff-4de9b4566fbbfeadb336115f0c5645afa244230a1e92db9235d566a4c834e09aR303-R309) [[4]](diffhunk://#diff-4de9b4566fbbfeadb336115f0c5645afa244230a1e92db9235d566a4c834e09aR336-R340) [[5]](diffhunk://#diff-4de9b4566fbbfeadb336115f0c5645afa244230a1e92db9235d566a4c834e09aL571-R627) [[6]](diffhunk://#diff-ebdae3cbe65f7fb561f33b146f2bcacd5f79777aa89c0a48c63f9636c4e8b194R664-R687)
* Added an empty state UI for when no skills are installed, showing an inert "+" chip as a placeholder for future skill installation features.

**UI/UX and Visual Improvements:**

* Improved styling for the skills row, skill chips, and toast notifications, including new color schemes for enabled/disabled states and layout tweaks for better visual clarity. [[1]](diffhunk://#diff-43dba3975615c0d7d35d9df1a375ff01ab7b00e7fdc266da5ab2ac78b85575aeL464-R464) [[2]](diffhunk://#diff-43dba3975615c0d7d35d9df1a375ff01ab7b00e7fdc266da5ab2ac78b85575aeR486-R499) [[3]](diffhunk://#diff-ebdae3cbe65f7fb561f33b146f2bcacd5f79777aa89c0a48c63f9636c4e8b194L959-R983) [[4]](diffhunk://#diff-85aed52a7aa81cdd809d0a7e4d5e9f2b5cd7149f2db16cb16b536a7fb8f26cd2L145-R147)

**Internal API Consistency:**

* Propagated the new `requestWorkspaceSkills` method through relevant context and controller types to ensure all tool and prompt components can access workspace skills. [[1]](diffhunk://#diff-52519b4adbaeac2faf7e1195617cd662c582e776a0e89a13109913cce69851b7R17) [[2]](diffhunk://#diff-52519b4adbaeac2faf7e1195617cd662c582e776a0e89a13109913cce69851b7R31) [[3]](diffhunk://#diff-52519b4adbaeac2faf7e1195617cd662c582e776a0e89a13109913cce69851b7R60) [[4]](diffhunk://#diff-52519b4adbaeac2faf7e1195617cd662c582e776a0e89a13109913cce69851b7R128)