### PR TITLE
Implement workspace skills support and refactor skill selection UI

### DIFF
--- a/src/clihub/main.ts
+++ b/src/clihub/main.ts
@@ -17,7 +17,7 @@ import {
 import type { VoiceState } from './webview/core/tools-cli-core/modal-voice/voice-types';
 import { checkText as spellCheckText, warmSpellchecker } from './webview/core/tools-cli-core/autocorrect/host-spellcheck';
 import { preparePromptForCLI } from './webview/core/tools-cli-core/prompt/attachments/host-preparer';
-import type { ImageAttachment } from './webview/core/tools-cli-core/prompt';
+import type { ImageAttachment, SkillRoot, WorkspaceSkill } from './webview/core/tools-cli-core/prompt';
 import {
 	getAgentLaunchGuardMessage,
 	type AgentLaunchExtensionMode,
@@ -241,14 +241,18 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 		}
 
 		// A skill is a directory under one of these roots containing a SKILL.md.
-		// Only the folder name is surfaced; .agents takes precedence on duplicates.
-		const skillRoots = ['.agents/skills', '.claude/skills'];
-		const names = new Set<string>();
+		// Duplicated names collapse into one entry that remembers every root it
+		// lives in, so the webview can resolve the right copy per active CLI.
+		const skillRoots: Array<{ id: SkillRoot; rel: string }> = [
+			{ id: 'agents', rel: '.agents/skills' },
+			{ id: 'claude', rel: '.claude/skills' },
+		];
+		const rootsByName = new Map<string, SkillRoot[]>();
 		const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
 
 		if (workspaceFolder) {
 			for (const root of skillRoots) {
-				const rootUri = vscode.Uri.joinPath(workspaceFolder.uri, ...root.split('/'));
+				const rootUri = vscode.Uri.joinPath(workspaceFolder.uri, ...root.rel.split('/'));
 				let entries: Array<[string, vscode.FileType]>;
 				try {
 					entries = await vscode.workspace.fs.readDirectory(rootUri);
@@ -270,16 +274,20 @@ export class CliHubViewProvider implements vscode.WebviewViewProvider, vscode.Di
 
 				for (const name of await Promise.all(checks)) {
 					if (name) {
-						names.add(name);
+						rootsByName.set(name, [...(rootsByName.get(name) ?? []), root.id]);
 					}
 				}
 			}
 		}
 
+		const skills: WorkspaceSkill[] = [...rootsByName.entries()]
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([name, roots]) => ({ name, roots }));
+
 		await webview.postMessage({
 			type: 'workspace.skills',
 			id: message.id,
-			skills: [...names].sort(),
+			skills,
 		});
 	}
 

--- a/src/clihub/webview/core/tools-cli-core/autocorrect/host-spellcheck.ts
+++ b/src/clihub/webview/core/tools-cli-core/autocorrect/host-spellcheck.ts
@@ -13,7 +13,7 @@ export interface SpellIssue {
 // Segments that must never be flagged: code spans/blocks, URLs, emails, paths,
 // CLI flags, hex colors, ACRONYMS, file names, and dotted identifiers.
 // Lifted verbatim from the former local-replacer so behavior stays consistent.
-const protectedPattern = /\[(?:Image|Code|Text) #\d+[^\]\n]*\]|\[Skill #[^\]\n]+\]|```[\s\S]*?```|`[^`\n]+`|https?:\/\/[^\s"'`<>]+|[\w.-]+@[\w.-]+\.\w{2,}|(?:\.{1,2}\/|~\/|\/)[^\s"'`<>]+|[A-Za-z]:\\[^\s"'`<>]+|#[0-9a-fA-F]{3,8}\b|\b[A-Z][A-Z0-9_]{1,}\b|(?<!\S)--?[A-Za-z][\w-]*(?:=[^\s"'`<>]+)?|\b(?:@[\w.-]+\/)?[\w.-]+@[\w.-]+\b|\b[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|html|css|scss|sass|md|mdx|svg|png|jpg|jpeg|gif|webp|yml|yaml|toml|env|lock)\b|\b[$A-Za-z_][\w$]*(?:[._:$][\w$-]+)+\b/g;
+const protectedPattern = /\[(?:Image|Code|Text) #\d+[^\]\n]*\]|\[Skills? #[^\]\n]+\]|\/skills #\d+|\/skill\b|```[\s\S]*?```|`[^`\n]+`|https?:\/\/[^\s"'`<>]+|[\w.-]+@[\w.-]+\.\w{2,}|(?:\.{1,2}\/|~\/|\/)[^\s"'`<>]+|[A-Za-z]:\\[^\s"'`<>]+|#[0-9a-fA-F]{3,8}\b|\b[A-Z][A-Z0-9_]{1,}\b|(?<!\S)--?[A-Za-z][\w-]*(?:=[^\s"'`<>]+)?|\b(?:@[\w.-]+\/)?[\w.-]+@[\w.-]+\b|\b[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|html|css|scss|sass|md|mdx|svg|png|jpg|jpeg|gif|webp|yml|yaml|toml|env|lock)\b|\b[$A-Za-z_][\w$]*(?:[._:$][\w$-]+)+\b/g;
 const wordPattern = /\p{L}+/gu;
 
 // Known personal typos worth flagging even when the dictionary is lenient.

--- a/src/clihub/webview/core/tools-cli-core/autocorrect/host-spellcheck.ts
+++ b/src/clihub/webview/core/tools-cli-core/autocorrect/host-spellcheck.ts
@@ -13,7 +13,7 @@ export interface SpellIssue {
 // Segments that must never be flagged: code spans/blocks, URLs, emails, paths,
 // CLI flags, hex colors, ACRONYMS, file names, and dotted identifiers.
 // Lifted verbatim from the former local-replacer so behavior stays consistent.
-const protectedPattern = /\[(?:Image|Code|Text) #\d+[^\]\n]*\]|```[\s\S]*?```|`[^`\n]+`|https?:\/\/[^\s"'`<>]+|[\w.-]+@[\w.-]+\.\w{2,}|(?:\.{1,2}\/|~\/|\/)[^\s"'`<>]+|[A-Za-z]:\\[^\s"'`<>]+|#[0-9a-fA-F]{3,8}\b|\b[A-Z][A-Z0-9_]{1,}\b|(?<!\S)--?[A-Za-z][\w-]*(?:=[^\s"'`<>]+)?|\b(?:@[\w.-]+\/)?[\w.-]+@[\w.-]+\b|\b[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|html|css|scss|sass|md|mdx|svg|png|jpg|jpeg|gif|webp|yml|yaml|toml|env|lock)\b|\b[$A-Za-z_][\w$]*(?:[._:$][\w$-]+)+\b/g;
+const protectedPattern = /\[(?:Image|Code|Text) #\d+[^\]\n]*\]|\[Skill #[^\]\n]+\]|```[\s\S]*?```|`[^`\n]+`|https?:\/\/[^\s"'`<>]+|[\w.-]+@[\w.-]+\.\w{2,}|(?:\.{1,2}\/|~\/|\/)[^\s"'`<>]+|[A-Za-z]:\\[^\s"'`<>]+|#[0-9a-fA-F]{3,8}\b|\b[A-Z][A-Z0-9_]{1,}\b|(?<!\S)--?[A-Za-z][\w-]*(?:=[^\s"'`<>]+)?|\b(?:@[\w.-]+\/)?[\w.-]+@[\w.-]+\b|\b[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|html|css|scss|sass|md|mdx|svg|png|jpg|jpeg|gif|webp|yml|yaml|toml|env|lock)\b|\b[$A-Za-z_][\w$]*(?:[._:$][\w$-]+)+\b/g;
 const wordPattern = /\p{L}+/gu;
 
 // Known personal typos worth flagging even when the dictionary is lenient.

--- a/src/clihub/webview/core/tools-cli-core/prompt/attachments/markers.ts
+++ b/src/clihub/webview/core/tools-cli-core/prompt/attachments/markers.ts
@@ -1,4 +1,5 @@
 import { pasteMarkerPattern } from './pastes';
+import { skillTokenPattern } from '../skills';
 
 export const imageMarkerPattern = /\[Image #(\d+)\]/g;
 
@@ -7,15 +8,39 @@ export const mentionTokenPattern = /(?<=^|\s)@\S+/g;
 
 /**
  * Text with all non-typed tokens removed: image markers, collapsed-paste
- * markers, and @mentions. This is what the char counter should measure — the
- * tokens expand/resolve outside the textarea and are never translated, so
- * they shouldn't spend the user's prompt budget.
+ * markers, skill tokens, and @mentions. This is what the char counter should
+ * measure — the tokens expand/resolve outside the textarea and are never
+ * translated, so they shouldn't spend the user's prompt budget.
  */
 export function stripPromptTokens(text: string): string {
 	return text
 		.replace(imageMarkerPattern, '')
 		.replace(pasteMarkerPattern, '')
+		.replace(skillTokenPattern, '')
 		.replace(mentionTokenPattern, '');
+}
+
+export interface ProtectedSkillToken {
+	token: string;
+	placeholder: string;
+}
+
+/** Shield [Skill #name] tokens from translation, mirroring protectImageMarkers. */
+export function protectSkillTokens(text: string): { text: string; tokens: ProtectedSkillToken[] } {
+	const tokens: ProtectedSkillToken[] = [];
+	let index = 0;
+	const protectedText = text.replace(skillTokenPattern, (token) => {
+		const placeholder = `ZXQCLIHUBSKL${index++}QXZ`;
+		tokens.push({ token, placeholder });
+		return placeholder;
+	});
+	return { text: protectedText, tokens };
+}
+
+export function restoreSkillTokens(text: string, tokens: ProtectedSkillToken[]): string {
+	return tokens.reduce((result, { token, placeholder }) => {
+		return result.split(placeholder).join(token);
+	}, text);
 }
 
 export interface ProtectedMention {

--- a/src/clihub/webview/core/tools-cli-core/prompt/attachments/markers.ts
+++ b/src/clihub/webview/core/tools-cli-core/prompt/attachments/markers.ts
@@ -1,5 +1,5 @@
 import { pasteMarkerPattern } from './pastes';
-import { skillTokenPattern } from '../skills';
+import { skillsTokenPattern } from '../skills';
 
 export const imageMarkerPattern = /\[Image #(\d+)\]/g;
 
@@ -16,7 +16,7 @@ export function stripPromptTokens(text: string): string {
 	return text
 		.replace(imageMarkerPattern, '')
 		.replace(pasteMarkerPattern, '')
-		.replace(skillTokenPattern, '')
+		.replace(skillsTokenPattern, '')
 		.replace(mentionTokenPattern, '');
 }
 
@@ -25,11 +25,11 @@ export interface ProtectedSkillToken {
 	placeholder: string;
 }
 
-/** Shield [Skill #name] tokens from translation, mirroring protectImageMarkers. */
+/** Shield [Skills #N] aggregate tokens from translation, mirroring protectImageMarkers. */
 export function protectSkillTokens(text: string): { text: string; tokens: ProtectedSkillToken[] } {
 	const tokens: ProtectedSkillToken[] = [];
 	let index = 0;
-	const protectedText = text.replace(skillTokenPattern, (token) => {
+	const protectedText = text.replace(skillsTokenPattern, (token) => {
 		const placeholder = `ZXQCLIHUBSKL${index++}QXZ`;
 		tokens.push({ token, placeholder });
 		return placeholder;

--- a/src/clihub/webview/core/tools-cli-core/prompt/index.ts
+++ b/src/clihub/webview/core/tools-cli-core/prompt/index.ts
@@ -13,7 +13,19 @@ export {
 	stripPromptTokens,
 	protectMentions,
 	restoreMentions,
+	protectSkillTokens,
+	restoreSkillTokens,
 } from './attachments/markers';
+
+// Workspace skills: [Skill #name] tokens in the textarea, expanded on send
+// into instructions with the SKILL.md route resolved for the active CLI.
+export {
+	skillTokenPattern,
+	buildSkillToken,
+	resolveSkillPath,
+	expandSkillTokens,
+} from './skills';
+export type { WorkspaceSkill, SkillRoot } from './skills';
 export type { ImageAttachment } from './attachments/types';
 export { isImageAttachment } from './attachments/types';
 export { buildPromptTextWithImages } from './attachments/prepare';

--- a/src/clihub/webview/core/tools-cli-core/prompt/index.ts
+++ b/src/clihub/webview/core/tools-cli-core/prompt/index.ts
@@ -17,13 +17,13 @@ export {
 	restoreSkillTokens,
 } from './attachments/markers';
 
-// Workspace skills: [Skill #name] tokens in the textarea, expanded on send
-// into instructions with the SKILL.md route resolved for the active CLI.
+// Workspace skills: one aggregate [Skills #N] token in the textarea, expanded
+// on send into instructions with each SKILL.md route resolved for the active CLI.
 export {
-	skillTokenPattern,
-	buildSkillToken,
+	skillsTokenPattern,
+	buildSkillsToken,
 	resolveSkillPath,
-	expandSkillTokens,
+	expandSkillsToken,
 } from './skills';
 export type { WorkspaceSkill, SkillRoot } from './skills';
 export type { ImageAttachment } from './attachments/types';

--- a/src/clihub/webview/core/tools-cli-core/prompt/skills.ts
+++ b/src/clihub/webview/core/tools-cli-core/prompt/skills.ts
@@ -1,0 +1,89 @@
+/**
+ * Workspace skills support for the prompt chat, mirroring the [Image #N]
+ * token system: clicking a skill chip inserts an atomic "[Skill #name]"
+ * token in the textarea, and on send each token expands into an explicit
+ * instruction with the SKILL.md route resolved for the active CLI.
+ *
+ * A skill is a folder containing a SKILL.md under one of two roots:
+ *   .claude/skills/  — Claude Code's native location
+ *   .agents/skills/  — the cross-agent convention
+ * The host surfaces the union deduplicated by name, remembering which
+ * roots hold each skill so the send-time path can prefer the right copy
+ * (.claude for Claude sessions, .agents for everything else).
+ */
+
+export type SkillRoot = 'agents' | 'claude';
+
+export interface WorkspaceSkill {
+	name: string;
+	roots: SkillRoot[];
+}
+
+export const skillRootDirs: Record<SkillRoot, string> = {
+	agents: '.agents/skills',
+	claude: '.claude/skills',
+};
+
+export const skillTokenPattern = /\[Skill #([^\]]+)\]/g;
+
+export function buildSkillToken(name: string): string {
+	return `[Skill #${name}]`;
+}
+
+/** Relative SKILL.md route, preferring the copy the active CLI reads natively. */
+export function resolveSkillPath(skill: WorkspaceSkill, preferClaude: boolean): string {
+	const preferred: SkillRoot = preferClaude ? 'claude' : 'agents';
+	const root = skill.roots.includes(preferred) ? preferred : (skill.roots[0] ?? preferred);
+	return `${skillRootDirs[root]}/${skill.name}/SKILL.md`;
+}
+
+/**
+ * Expand [Skill #name] tokens into CLI-readable instructions.
+ *
+ * Tokens leading the prompt (the chip-click default) collapse into one
+ * explicit header sentence; tokens used mid-sentence become an inline
+ * reference at their position. Unknown names are left untouched so a stale
+ * draft never corrupts the prompt. Always called after translation — the
+ * generated English must never go through the translator.
+ */
+export function expandSkillTokens(text: string, skills: WorkspaceSkill[], preferClaude: boolean): string {
+	if (!skills.length) {
+		return text;
+	}
+
+	const byName = new Map(skills.map((skill) => [skill.name, skill]));
+
+	// Peel known tokens off the start of the prompt.
+	const leading: WorkspaceSkill[] = [];
+	let rest = text;
+	for (;;) {
+		const match = /^\s*\[Skill #([^\]]+)\]/.exec(rest);
+		const skill = match ? byName.get(match[1]) : undefined;
+		if (!match || !skill) {
+			break;
+		}
+		leading.push(skill);
+		rest = rest.slice(match[0].length);
+	}
+	rest = rest.trimStart();
+
+	// Remaining tokens read naturally in place: «use [Skill #x] for…» becomes
+	// «use "x" (.agents/skills/x/SKILL.md) for…».
+	rest = rest.replace(skillTokenPattern, (token, name: string) => {
+		const skill = byName.get(name);
+		return skill ? `"${skill.name}" (${resolveSkillPath(skill, preferClaude)})` : token;
+	});
+
+	if (!leading.length) {
+		return rest;
+	}
+
+	const references = leading.map(
+		(skill) => `"${skill.name}" (read ${resolveSkillPath(skill, preferClaude)})`
+	);
+	const header = leading.length === 1
+		? `Use the "${leading[0].name}" skill (read ${resolveSkillPath(leading[0], preferClaude)}).`
+		: `Use these skills: ${references.join(', ')}.`;
+
+	return rest ? `${header}\n\n${rest}` : header;
+}

--- a/src/clihub/webview/core/tools-cli-core/prompt/skills.ts
+++ b/src/clihub/webview/core/tools-cli-core/prompt/skills.ts
@@ -1,8 +1,10 @@
 /**
- * Workspace skills support for the prompt chat, mirroring the [Image #N]
- * token system: clicking a skill chip inserts an atomic "[Skill #name]"
- * token in the textarea, and on send each token expands into an explicit
- * instruction with the SKILL.md route resolved for the active CLI.
+ * Workspace skills support for the prompt chat. Selected skills are
+ * represented by ONE compact aggregate token in the textarea — "[Skills #2]"
+ * — whose count updates in place as chips toggle. The token is purely a
+ * visual indicator: the ordered chip selection is authoritative, and on send
+ * it expands into an explicit instruction with each SKILL.md route resolved
+ * for the active CLI.
  *
  * A skill is a folder containing a SKILL.md under one of two roots:
  *   .claude/skills/  — Claude Code's native location
@@ -24,10 +26,12 @@ export const skillRootDirs: Record<SkillRoot, string> = {
 	claude: '.claude/skills',
 };
 
-export const skillTokenPattern = /\[Skill #([^\]]+)\]/g;
+// Matches the compact tokens (/skill singular, /skills #N plural) and legacy
+// bracket shapes so old drafts still clean up correctly.
+export const skillsTokenPattern = /\/skills #\d+|\/skill(?!s)|\[Skills? #[^\]]+\]/g;
 
-export function buildSkillToken(name: string): string {
-	return `[Skill #${name}]`;
+export function buildSkillsToken(count: number): string {
+	return count === 1 ? '/skill' : `/skills #${count}`;
 }
 
 /** Relative SKILL.md route, preferring the copy the active CLI reads natively. */
@@ -38,52 +42,23 @@ export function resolveSkillPath(skill: WorkspaceSkill, preferClaude: boolean): 
 }
 
 /**
- * Expand [Skill #name] tokens into CLI-readable instructions.
- *
- * Tokens leading the prompt (the chip-click default) collapse into one
- * explicit header sentence; tokens used mid-sentence become an inline
- * reference at their position. Unknown names are left untouched so a stale
- * draft never corrupts the prompt. Always called after translation — the
- * generated English must never go through the translator.
+ * Strip the visual token(s) and prepend the real instruction, listing the
+ * selected skills in selection order with their resolved SKILL.md routes.
+ * Always called after translation — the generated English must never go
+ * through the translator.
  */
-export function expandSkillTokens(text: string, skills: WorkspaceSkill[], preferClaude: boolean): string {
-	if (!skills.length) {
-		return text;
+export function expandSkillsToken(text: string, selected: WorkspaceSkill[], preferClaude: boolean): string {
+	const cleaned = text.replace(/\/skills #\d+ ?|\/skill(?!s) ?|\[Skills? #[^\]]+\] ?/g, '').trimStart();
+
+	if (!selected.length) {
+		return cleaned;
 	}
 
-	const byName = new Map(skills.map((skill) => [skill.name, skill]));
+	const header = selected.length === 1
+		? `Use the "${selected[0].name}" skill (read ${resolveSkillPath(selected[0], preferClaude)}).`
+		: `Use these skills: ${selected
+				.map((skill) => `"${skill.name}" (read ${resolveSkillPath(skill, preferClaude)})`)
+				.join(', ')}.`;
 
-	// Peel known tokens off the start of the prompt.
-	const leading: WorkspaceSkill[] = [];
-	let rest = text;
-	for (;;) {
-		const match = /^\s*\[Skill #([^\]]+)\]/.exec(rest);
-		const skill = match ? byName.get(match[1]) : undefined;
-		if (!match || !skill) {
-			break;
-		}
-		leading.push(skill);
-		rest = rest.slice(match[0].length);
-	}
-	rest = rest.trimStart();
-
-	// Remaining tokens read naturally in place: «use [Skill #x] for…» becomes
-	// «use "x" (.agents/skills/x/SKILL.md) for…».
-	rest = rest.replace(skillTokenPattern, (token, name: string) => {
-		const skill = byName.get(name);
-		return skill ? `"${skill.name}" (${resolveSkillPath(skill, preferClaude)})` : token;
-	});
-
-	if (!leading.length) {
-		return rest;
-	}
-
-	const references = leading.map(
-		(skill) => `"${skill.name}" (read ${resolveSkillPath(skill, preferClaude)})`
-	);
-	const header = leading.length === 1
-		? `Use the "${leading[0].name}" skill (read ${resolveSkillPath(leading[0], preferClaude)}).`
-		: `Use these skills: ${references.join(', ')}.`;
-
-	return rest ? `${header}\n\n${rest}` : header;
+	return cleaned ? `${header}\n\n${cleaned}` : header;
 }

--- a/src/clihub/webview/ui/panel-terminal/terminal.ts
+++ b/src/clihub/webview/ui/panel-terminal/terminal.ts
@@ -4,7 +4,7 @@ import { createTabController, type CliAgentIcon, type CliAgentOption, type CliSe
 import { createCliCreateMessage, type AgentLaunchGuardMessage } from './agent-safety/agent-launch-guard';
 import { createToolsController } from './tools-cli-ui/tools';
 import { detectModelName } from '../../core/terminal-cli/model-detect';
-import type { ImageAttachment, PromptTranslateRequest, PromptTranslateResult, FileMentionEntry, SpellIssue } from '../../core/tools-cli-core/prompt';
+import type { ImageAttachment, PromptTranslateRequest, PromptTranslateResult, FileMentionEntry, SpellIssue, WorkspaceSkill } from '../../core/tools-cli-core/prompt';
 import type { VoiceState } from '../../core/tools-cli-core/modal-voice/voice-types';
 
 type VsCodeApi = {
@@ -49,7 +49,7 @@ type ServerMessage =
 	| { type: 'prompt.prepareError'; id: string; message: string }
 	| { type: 'prompt.spellResult'; id: string; issues: SpellIssue[] }
 	| { type: 'workspace.files'; id: string; files: FileMentionEntry[] }
-	| { type: 'workspace.skills'; id: string; skills: string[] }
+	| { type: 'workspace.skills'; id: string; skills: WorkspaceSkill[] }
 	| { type: 'voice.state'; state: VoiceState; message?: string }
 	| { type: 'clipboard.text'; id: string; text: string };
 
@@ -310,10 +310,10 @@ const requestWorkspaceFiles = (): Promise<FileMentionEntry[]> => {
 	});
 };
 
-const pendingWorkspaceSkills = new Map<string, (skills: string[]) => void>();
+const pendingWorkspaceSkills = new Map<string, (skills: WorkspaceSkill[]) => void>();
 let nextWorkspaceSkillsId = 1;
 
-const requestWorkspaceSkills = (): Promise<string[]> => {
+const requestWorkspaceSkills = (): Promise<WorkspaceSkill[]> => {
 	const id = `ws-skills-${nextWorkspaceSkillsId++}`;
 	return new Promise((resolve) => {
 		const timeout = window.setTimeout(() => {

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
@@ -569,6 +569,13 @@
   box-shadow: 0 0 0 1px color-mix(in srgb, #e879f9 35%, transparent);
 }
 
+/* Skill tokens — [Skill #cavecrew], violet to match the skill chips */
+.prompt-textarea-highlight .prompt-skill-marker {
+  background: color-mix(in srgb, #a78bfa 16%, transparent);
+  color: #a78bfa;
+  box-shadow: 0 0 0 1px color-mix(in srgb, #a78bfa 35%, transparent);
+}
+
 /* When a paste marker is (partially) selected, the selection style wins */
 .prompt-textarea-highlight .selected .prompt-paste-marker,
 .prompt-textarea-highlight .selected.prompt-paste-marker {

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css
@@ -569,11 +569,55 @@
   box-shadow: 0 0 0 1px color-mix(in srgb, #e879f9 35%, transparent);
 }
 
-/* Skill tokens — [Skill #cavecrew], violet to match the skill chips */
+/* Skill token — /skills #N, plain violet text, no box decoration */
 .prompt-textarea-highlight .prompt-skill-marker {
-  background: color-mix(in srgb, #a78bfa 16%, transparent);
   color: #a78bfa;
-  box-shadow: 0 0 0 1px color-mix(in srgb, #a78bfa 35%, transparent);
+  font-weight: 600;
+}
+
+/* Numbered badge on selected skill chips ("#1", "#2") */
+.prompt-skill-chip .skill-badge {
+  display: none;
+  font-size: 9px;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  color: #a78bfa;
+  letter-spacing: 0;
+  line-height: 1;
+}
+.prompt-skill-chip.selected .skill-badge {
+  display: inline-block;
+  animation: badge-pop 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  transform-origin: center bottom;
+}
+@keyframes badge-pop {
+  0%   { transform: scale(0) translateY(3px); opacity: 0; }
+  60%  { transform: scale(1.3) translateY(-1px); opacity: 1; }
+  100% { transform: scale(1) translateY(0); opacity: 1; }
+}
+
+/* Skill chips: fixed violet independent of the active CLI theme.
+   Double-class specificity beats the .agent-shell[data-agent] .prompt-tool-btn:hover rule. */
+.prompt-tool-btn.prompt-skill-chip:hover,
+.agent-shell[data-agent] .prompt-tool-btn.prompt-skill-chip:hover {
+  background: color-mix(in srgb, #7c3aed 12%, var(--vscode-input-background));
+  border-color: color-mix(in srgb, #7c3aed 35%, var(--vscode-editorGroup-border));
+  color: #a78bfa;
+}
+.prompt-tool-btn.prompt-skill-chip.selected,
+.agent-shell[data-agent] .prompt-tool-btn.prompt-skill-chip.selected {
+  border-color: color-mix(in srgb, #7c3aed 40%, var(--vscode-editorGroup-border));
+  color: #a78bfa;
+  box-shadow: 0 0 0 3px color-mix(in srgb, #a78bfa 15%, transparent);
+}
+.prompt-tool-btn.prompt-skill-chip.selected::after,
+.agent-shell[data-agent] .prompt-tool-btn.prompt-skill-chip.selected::after {
+  background: linear-gradient(
+    115deg,
+    transparent 25%,
+    color-mix(in srgb, #fff 35%, #a78bfa) 42%,
+    transparent 60%
+  );
 }
 
 /* When a paste marker is (partially) selected, the selection style wins */
@@ -703,7 +747,7 @@
 /* Tool buttons (Skills chips) */
 .prompt-tools {
   display: flex;
-  gap: 6px;
+  gap: 10px;
   flex-wrap: wrap;
 }
 

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.html
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.html
@@ -55,7 +55,8 @@
       <span class="prompt-char-count" id="charCount">0/5000</span>
     </div>
     <!-- Chips are populated at mount with the skills installed in the
-         workspace (.agents/skills + .claude/skills); hidden when none. -->
+         workspace (.agents/skills + .claude/skills); hidden when none.
+         One aggregate /skills #N token represents the selection. -->
     <div class="prompt-skills" hidden>
       <span class="prompt-skills-label">Skills:</span>
       <div class="prompt-tools" id="skillChips"></div>

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
@@ -23,6 +23,11 @@ import {
 	stripPromptTokens,
 	protectMentions,
 	restoreMentions,
+	type WorkspaceSkill,
+	buildSkillToken,
+	expandSkillTokens,
+	protectSkillTokens,
+	restoreSkillTokens,
 } from '../../../../core/tools-cli-core/prompt';
 import { mountFileMentionPicker } from './components/file-mention/file-mention';
 
@@ -44,9 +49,10 @@ const ensureStyles = () => {
 const imagePathPattern =
 	/(?:"([^"\r\n]+\.(?:png|jpe?g|gif|webp|bmp|svg|tiff?))"|'([^'\r\n]+\.(?:png|jpe?g|gif|webp|bmp|svg|tiff?))'|((?:~|\/)[^\r\n\t"'<>]*?\.(?:png|jpe?g|gif|webp|bmp|svg|tiff?)))/gi;
 
-// Every atomic token in the textarea: [Image #N], [Code #N +X lines], [Text #N +X lines].
-// Used by delete/arrow/caret handling so all marker types behave as single units.
-const atomicMarkerPattern = /\[(?:Image|Code|Text) #\d+[^\]]*\]/g;
+// Every atomic token in the textarea: [Image #N], [Code #N +X lines],
+// [Text #N +X lines], [Skill #name]. Used by delete/arrow/caret handling so
+// all marker types behave as single units.
+const atomicMarkerPattern = /\[(?:Image|Code|Text) #\d+[^\]]*\]|\[Skill #[^\]]+\]/g;
 
 // Budget for the *effective* typed text — markers and @mentions are free, and
 // large pastes collapse into markers, so this only constrains hand-typed prose.
@@ -77,7 +83,7 @@ type PromptContext = {
 	translatePrompt?: (request: PromptTranslateRequest) => Promise<PromptTranslateResult>;
 	preparePromptWithAttachments?: (text: string, attachments: ImageAttachment[]) => Promise<string>;
 	requestWorkspaceFiles?: () => Promise<FileMentionEntry[]>;
-	requestWorkspaceSkills?: () => Promise<string[]>;
+	requestWorkspaceSkills?: () => Promise<WorkspaceSkill[]>;
 	requestSpellcheck?: (text: string, strict: boolean) => Promise<SpellIssue[]>;
 };
 
@@ -269,15 +275,16 @@ function initPromptTabs(host: HTMLElement, context: PromptContext, hasActiveSess
 				runBtn.innerHTML = '<i class="ti ti-sparkles" aria-hidden="true"></i><span>Translating…</span>';
 			}
 			try {
-				// Image markers, paste markers AND @mention routes must survive
-				// translation untouched — they also shrink the payload the
-				// translator has to process, so requests are faster and safer.
+				// Image markers, paste markers, skill tokens AND @mention routes
+				// must survive translation untouched — they also shrink the payload
+				// the translator has to process, so requests are faster and safer.
 				const { text: imageProtected, markers } = protectImageMarkers(textToSend);
 				const { text: pasteProtected, markers: pasteMarkers } = protectPasteMarkers(imageProtected);
-				const { text: protectedText, mentions } = protectMentions(pasteProtected);
+				const { text: skillProtected, tokens: skillTokens } = protectSkillTokens(pasteProtected);
+				const { text: protectedText, mentions } = protectMentions(skillProtected);
 				const result = await translatePromptText(protectedText, ctx);
 				const translated = result.text
-					? restoreImageMarkers(restorePasteMarkers(restoreMentions(result.text, mentions), pasteMarkers), markers)
+					? restoreImageMarkers(restorePasteMarkers(restoreSkillTokens(restoreMentions(result.text, mentions), skillTokens), pasteMarkers), markers)
 					: '';
 				if (translated && translated !== textToSend.trim()) {
 					textToSend = translated;
@@ -304,16 +311,17 @@ function initPromptTabs(host: HTMLElement, context: PromptContext, hasActiveSess
 			}
 		}
 
+		// [Skill #name] tokens expand into explicit instructions with the
+		// SKILL.md route resolved for the active CLI (.claude/skills for
+		// Claude, .agents/skills for the rest, falling back to wherever the
+		// skill exists). Done post-translation — the generated text is already
+		// English — and before paste expansion so pasted content that happens
+		// to contain a token-looking string can never be expanded.
+		textToSend = expandSkillTokens(textToSend, workspaceSkills, isClaudeSession());
+
 		// Collapsed pastes leave the textarea as markers; the CLI gets the
 		// original verbatim content (never lowercased, never translated).
 		textToSend = expandPasteMarkers(textToSend, pasteAttachments);
-
-		// Selected skill chips ride along as an explicit instruction. Appended
-		// post-translation (already English) so it never hits the translator.
-		if (selectedSkills.size > 0) {
-			const names = [...selectedSkills].map((name) => `"${name}"`).join(', ');
-			textToSend += `\n\nUse the following skill${selectedSkills.size === 1 ? '' : 's'}: ${names}.`;
-		}
 
 		const result = processPrompt(textToSend, {
 			close: ctx.close,
@@ -341,11 +349,15 @@ function initPromptTabs(host: HTMLElement, context: PromptContext, hasActiveSess
 		textarea.focus();
 	});
 
-	// Skills the user toggles on travel with the prompt as an explicit instruction.
-	const selectedSkills = new Set<string>();
+	// Workspace skills, kept for send-time path resolution. The textarea is the
+	// source of truth for *selection*: a chip is "on" while its [Skill #name]
+	// token is present in the text.
+	let workspaceSkills: WorkspaceSkill[] = [];
 
 	if (hasActiveSession) {
-		initSkillsChips(host, context, selectedSkills);
+		initSkillsChips(host, context, textarea, (skills) => {
+			workspaceSkills = skills;
+		});
 		const tools = initToolbarActions(
 			host,
 			() => translateState.enabled,
@@ -587,10 +599,47 @@ function enforceLowercaseInput(textarea: HTMLTextAreaElement) {
 	});
 }
 
+// The active CLI decides which skills folder a route should prefer. Same
+// label source updateFooterModel uses.
+function isClaudeSession(): boolean {
+	const label = document.getElementById('cli-terminal-label')?.textContent ?? '';
+	return label.toLowerCase().includes('claude');
+}
+
+// Insert the skill token at the start of the prompt (where instructions land
+// hardest) or remove it everywhere — clicking the chip toggles between both.
+function toggleSkillToken(textarea: HTMLTextAreaElement, name: string) {
+	const token = buildSkillToken(name);
+	const caret = textarea.selectionStart ?? textarea.value.length;
+
+	if (textarea.value.includes(token)) {
+		// Remove every occurrence, eating one following space when present.
+		const newValue = textarea.value.split(token + ' ').join('').split(token).join('');
+		textarea.value = newValue;
+		const pos = Math.min(caret, newValue.length);
+		textarea.setSelectionRange(pos, pos);
+	} else {
+		const prefix = token + ' ';
+		textarea.value = prefix + textarea.value;
+		const pos = caret + prefix.length;
+		textarea.setSelectionRange(pos, pos);
+	}
+
+	textarea.focus();
+	textarea.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
 // Populate the Skills row with the skills installed in the workspace
 // (.agents/skills/* and .claude/skills/*, folders containing a SKILL.md —
-// scanned host-side). The row only appears when at least one skill exists.
-function initSkillsChips(host: HTMLElement, context: PromptContext, selectedSkills: Set<string>) {
+// scanned host-side, deduplicated by name). The row only appears when at
+// least one skill exists. Chips mirror the [Skill #name] tokens in the
+// textarea: clicking toggles the token, deleting the token unselects the chip.
+function initSkillsChips(
+	host: HTMLElement,
+	context: PromptContext,
+	textarea: HTMLTextAreaElement,
+	onSkillsLoaded: (skills: WorkspaceSkill[]) => void
+) {
 	const row = host.querySelector<HTMLElement>('.prompt-skills');
 	const chipsHost = host.querySelector<HTMLElement>('#skillChips');
 	if (!row || !chipsHost || !context.requestWorkspaceSkills) {
@@ -602,6 +651,7 @@ function initSkillsChips(host: HTMLElement, context: PromptContext, selectedSkil
 			return;
 		}
 
+		onSkillsLoaded(skills);
 		chipsHost.replaceChildren();
 
 		// No skills installed: show an inert dashed "+" placeholder.
@@ -617,22 +667,28 @@ function initSkillsChips(host: HTMLElement, context: PromptContext, selectedSkil
 			return;
 		}
 
-		for (const name of skills) {
+		const chipByName = new Map<string, HTMLButtonElement>();
+		const syncChips = () => {
+			for (const [name, chip] of chipByName) {
+				chip.classList.toggle('selected', textarea.value.includes(buildSkillToken(name)));
+			}
+		};
+
+		for (const skill of skills) {
 			const chip = document.createElement('button');
 			chip.className = 'prompt-tool-btn';
-			chip.dataset.skill = name;
-			chip.textContent = name;
-			chip.title = `Ask the CLI to use its "${name}" skill`;
-			chip.addEventListener('click', () => {
-				if (chip.classList.toggle('selected')) {
-					selectedSkills.add(name);
-				} else {
-					selectedSkills.delete(name);
-				}
-			});
+			chip.dataset.skill = skill.name;
+			chip.textContent = skill.name;
+			chip.title = `Ask the CLI to use its "${skill.name}" skill`;
+			chip.addEventListener('click', () => toggleSkillToken(textarea, skill.name));
+			chipByName.set(skill.name, chip);
 			chipsHost.append(chip);
 		}
 		row.hidden = false;
+
+		// Reflect tokens already present (restored drafts) and keep mirroring.
+		textarea.addEventListener('input', syncChips);
+		syncChips();
 	});
 }
 
@@ -1205,7 +1261,7 @@ function updatePromptImageHighlight(
   highlight.scrollLeft = textarea.scrollLeft;
 }
 
-type TokenKind = 'image' | 'mention' | 'mention-folder' | 'paste-code' | 'paste-text' | 'misspelled' | 'plain';
+type TokenKind = 'image' | 'mention' | 'mention-folder' | 'paste-code' | 'paste-text' | 'skill' | 'misspelled' | 'plain';
 
 function buildPromptHighlightNodes(text: string, selStart: number = -1, selEnd: number = -1, spellIssues: SpellIssue[] = []): Node[] {
   if (!text) {
@@ -1228,6 +1284,10 @@ function buildPromptHighlightNodes(text: string, selStart: number = -1, selEnd: 
     const kind: TokenKind = match[1] === 'Code' ? 'paste-code' : 'paste-text';
     tokens.push({ start: match.index ?? 0, end: (match.index ?? 0) + match[0].length, kind });
   }
+  // Skill tokens: [Skill #cavecrew] — expanded into a skill instruction on send.
+  for (const match of text.matchAll(/\[Skill #[^\]]+\]/g)) {
+    tokens.push({ start: match.index ?? 0, end: (match.index ?? 0) + match[0].length, kind: 'skill' });
+  }
   // @mention: '@' followed by any non-whitespace chars, must be preceded by whitespace or start of string
   for (const match of text.matchAll(/(?<=^|\s)@\S+/g)) {
     const kind: TokenKind = match[0].endsWith('/') ? 'mention-folder' : 'mention';
@@ -1240,7 +1300,7 @@ function buildPromptHighlightNodes(text: string, selStart: number = -1, selEnd: 
     }
   }
   // Image/mention tokens take priority over misspelled ones when ranges collide.
-  const tokenPriority: Record<TokenKind, number> = { image: 0, mention: 0, 'mention-folder': 0, 'paste-code': 0, 'paste-text': 0, misspelled: 1, plain: 2 };
+  const tokenPriority: Record<TokenKind, number> = { image: 0, mention: 0, 'mention-folder': 0, 'paste-code': 0, 'paste-text': 0, skill: 0, misspelled: 1, plain: 2 };
   tokens.sort((a, b) => a.start - b.start || tokenPriority[a.kind] - tokenPriority[b.kind]);
 
   for (const token of tokens) {
@@ -1288,6 +1348,7 @@ function appendSegment(
                  : kind === 'mention-folder' ? 'prompt-mention-folder'
                  : kind === 'paste-code' ? 'prompt-paste-marker prompt-paste-code'
                  : kind === 'paste-text' ? 'prompt-paste-marker prompt-paste-text'
+                 : kind === 'skill' ? 'prompt-paste-marker prompt-skill-marker'
                  : kind === 'misspelled' ? 'prompt-misspelled'
                  : 'plain';
 

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts
@@ -24,8 +24,8 @@ import {
 	protectMentions,
 	restoreMentions,
 	type WorkspaceSkill,
-	buildSkillToken,
-	expandSkillTokens,
+	buildSkillsToken,
+	expandSkillsToken,
 	protectSkillTokens,
 	restoreSkillTokens,
 } from '../../../../core/tools-cli-core/prompt';
@@ -52,7 +52,7 @@ const imagePathPattern =
 // Every atomic token in the textarea: [Image #N], [Code #N +X lines],
 // [Text #N +X lines], [Skill #name]. Used by delete/arrow/caret handling so
 // all marker types behave as single units.
-const atomicMarkerPattern = /\[(?:Image|Code|Text) #\d+[^\]]*\]|\[Skill #[^\]]+\]/g;
+const atomicMarkerPattern = /\[(?:Image|Code|Text) #\d+[^\]]*\]|\/skills #\d+|\/skill(?!s)/g;
 
 // Budget for the *effective* typed text — markers and @mentions are free, and
 // large pastes collapse into markers, so this only constrains hand-typed prose.
@@ -311,13 +311,11 @@ function initPromptTabs(host: HTMLElement, context: PromptContext, hasActiveSess
 			}
 		}
 
-		// [Skill #name] tokens expand into explicit instructions with the
-		// SKILL.md route resolved for the active CLI (.claude/skills for
-		// Claude, .agents/skills for the rest, falling back to wherever the
-		// skill exists). Done post-translation — the generated text is already
-		// English — and before paste expansion so pasted content that happens
-		// to contain a token-looking string can never be expanded.
-		textToSend = expandSkillTokens(textToSend, workspaceSkills, isClaudeSession());
+		// The [Skills #N] aggregate token expands into explicit instructions
+		// with each SKILL.md route resolved for the active CLI (.claude/skills
+		// for Claude, .agents/skills for the rest). Done post-translation —
+		// the generated text is already English — and before paste expansion.
+		textToSend = expandSkillsToken(textToSend, selectedSkills, isClaudeSession());
 
 		// Collapsed pastes leave the textarea as markers; the CLI gets the
 		// original verbatim content (never lowercased, never translated).
@@ -349,14 +347,14 @@ function initPromptTabs(host: HTMLElement, context: PromptContext, hasActiveSess
 		textarea.focus();
 	});
 
-	// Workspace skills, kept for send-time path resolution. The textarea is the
-	// source of truth for *selection*: a chip is "on" while its [Skill #name]
-	// token is present in the text.
-	let workspaceSkills: WorkspaceSkill[] = [];
+	// Ordered selection of skills — updated as the user toggles chips. The
+	// textarea holds only the aggregate [Skills #N] count token; the actual
+	// WorkspaceSkill objects live here and drive the send-time expansion.
+	let selectedSkills: WorkspaceSkill[] = [];
 
 	if (hasActiveSession) {
-		initSkillsChips(host, context, textarea, (skills) => {
-			workspaceSkills = skills;
+		initSkillsChips(host, context, textarea, (selection) => {
+			selectedSkills = selection;
 		});
 		const tools = initToolbarActions(
 			host,
@@ -606,39 +604,19 @@ function isClaudeSession(): boolean {
 	return label.toLowerCase().includes('claude');
 }
 
-// Insert the skill token at the start of the prompt (where instructions land
-// hardest) or remove it everywhere — clicking the chip toggles between both.
-function toggleSkillToken(textarea: HTMLTextAreaElement, name: string) {
-	const token = buildSkillToken(name);
-	const caret = textarea.selectionStart ?? textarea.value.length;
-
-	if (textarea.value.includes(token)) {
-		// Remove every occurrence, eating one following space when present.
-		const newValue = textarea.value.split(token + ' ').join('').split(token).join('');
-		textarea.value = newValue;
-		const pos = Math.min(caret, newValue.length);
-		textarea.setSelectionRange(pos, pos);
-	} else {
-		const prefix = token + ' ';
-		textarea.value = prefix + textarea.value;
-		const pos = caret + prefix.length;
-		textarea.setSelectionRange(pos, pos);
-	}
-
-	textarea.focus();
-	textarea.dispatchEvent(new Event('input', { bubbles: true }));
-}
-
 // Populate the Skills row with the skills installed in the workspace
-// (.agents/skills/* and .claude/skills/*, folders containing a SKILL.md —
-// scanned host-side, deduplicated by name). The row only appears when at
-// least one skill exists. Chips mirror the [Skill #name] tokens in the
-// textarea: clicking toggles the token, deleting the token unselects the chip.
+// (.agents/skills/* and .claude/skills/*, deduplicated by name, scanned
+// host-side). The row only appears when at least one skill exists.
+//
+// ONE aggregate [Skills #N] token in the textarea represents the selection.
+// The ordered `selected` array is authoritative; the token is purely visual.
+// Chips show numbered badges (#1, #2) that update as selection order changes.
+// A footer legend "skills: #1 cavecrew · #2 nido" appears when any are active.
 function initSkillsChips(
 	host: HTMLElement,
 	context: PromptContext,
 	textarea: HTMLTextAreaElement,
-	onSkillsLoaded: (skills: WorkspaceSkill[]) => void
+	onSelectionChange: (selected: WorkspaceSkill[]) => void
 ) {
 	const row = host.querySelector<HTMLElement>('.prompt-skills');
 	const chipsHost = host.querySelector<HTMLElement>('#skillChips');
@@ -651,11 +629,9 @@ function initSkillsChips(
 			return;
 		}
 
-		onSkillsLoaded(skills);
 		chipsHost.replaceChildren();
 
 		// No skills installed: show an inert dashed "+" placeholder.
-		// TODO(future): wire this to a skill install/create flow after the refactor.
 		if (!skills.length) {
 			const addChip = document.createElement('button');
 			addChip.className = 'prompt-tool-btn prompt-skill-add';
@@ -667,28 +643,111 @@ function initSkillsChips(
 			return;
 		}
 
-		const chipByName = new Map<string, HTMLButtonElement>();
-		const syncChips = () => {
-			for (const [name, chip] of chipByName) {
-				chip.classList.toggle('selected', textarea.value.includes(buildSkillToken(name)));
+		const selected: WorkspaceSkill[] = [];
+		let updatingToken = false;
+
+		const updateToken = () => {
+			updatingToken = true;
+			try {
+				// Match compact formats (/skill, /skills #N) and legacy bracket format
+				const hasToken = /\/skills #\d+|\/skill(?!s)|\[Skills? #[^\]]+\]/.test(textarea.value);
+
+				if (selected.length === 0) {
+					if (hasToken) {
+						textarea.value = textarea.value
+							.replace(/\/skills #\d+ ?|\/skill(?!s) ?|\[Skills? #[^\]]+\] ?/g, '')
+							.trimStart();
+						textarea.dispatchEvent(new Event('input', { bubbles: true }));
+					}
+				} else {
+					const newToken = buildSkillsToken(selected.length);
+					if (hasToken) {
+						textarea.value = textarea.value
+							.replace(/\/skills #\d+|\/skill(?!s)|\[Skills? #[^\]]+\]/g, newToken);
+					} else {
+						const current = textarea.value;
+						textarea.value = current ? `${newToken} ${current}` : newToken;
+					}
+					textarea.dispatchEvent(new Event('input', { bubbles: true }));
+				}
+
+				onSelectionChange([...selected]);
+			} finally {
+				updatingToken = false;
 			}
+		};
+
+		const syncBadges = () => {
+			for (const chip of Array.from(chipsHost!.querySelectorAll<HTMLButtonElement>('[data-skill]'))) {
+				const name = chip.dataset.skill!;
+				const idx = selected.findIndex((s) => s.name === name);
+				const badge = chip.querySelector<HTMLElement>('.skill-badge');
+				chip.classList.toggle('selected', idx >= 0);
+				if (badge) {
+					badge.textContent = idx >= 0 ? `#${idx + 1}` : '';
+				}
+			}
+		};
+
+		const sync = () => {
+			syncBadges();
 		};
 
 		for (const skill of skills) {
 			const chip = document.createElement('button');
-			chip.className = 'prompt-tool-btn';
+			chip.className = 'prompt-tool-btn prompt-skill-chip';
 			chip.dataset.skill = skill.name;
-			chip.textContent = skill.name;
 			chip.title = `Ask the CLI to use its "${skill.name}" skill`;
-			chip.addEventListener('click', () => toggleSkillToken(textarea, skill.name));
-			chipByName.set(skill.name, chip);
+
+			const label = document.createElement('span');
+			label.className = 'skill-label';
+			label.textContent = skill.name;
+
+			const badge = document.createElement('span');
+			badge.className = 'skill-badge';
+			badge.setAttribute('aria-hidden', 'true');
+
+			chip.append(label, badge);
+
+			chip.addEventListener('click', () => {
+				const idx = selected.findIndex((s) => s.name === skill.name);
+				if (idx >= 0) {
+					selected.splice(idx, 1);
+				} else {
+					selected.push(skill);
+				}
+				updateToken();
+				sync();
+				textarea.focus();
+			});
+
 			chipsHost.append(chip);
 		}
-		row.hidden = false;
 
-		// Reflect tokens already present (restored drafts) and keep mirroring.
-		textarea.addEventListener('input', syncChips);
-		syncChips();
+		row.hidden = false;
+		sync();
+
+		// Strip any stale skills token from a restored draft — the token
+		// doesn't encode skill names, so selection can't be reconstructed.
+		if (/\/skills #\d+|\/skill(?!s)|\[Skills? #[^\]]+\]/.test(textarea.value)) {
+			textarea.value = textarea.value
+				.replace(/\/skills #\d+ ?|\/skill(?!s) ?|\[Skills? #[^\]]+\] ?/g, '')
+				.trimStart();
+			textarea.dispatchEvent(new Event('input', { bubbles: true }));
+		}
+
+		// When the user manually deletes the token, clear the chip selection
+		// so the UI stays in sync with what the textarea contains.
+		textarea.addEventListener('input', () => {
+			if (updatingToken) {
+				return;
+			}
+			if (selected.length > 0 && !/\/skills #\d+|\/skill(?!s)/.test(textarea.value)) {
+				selected.length = 0;
+				onSelectionChange([]);
+				sync();
+			}
+		});
 	});
 }
 
@@ -1284,8 +1343,8 @@ function buildPromptHighlightNodes(text: string, selStart: number = -1, selEnd: 
     const kind: TokenKind = match[1] === 'Code' ? 'paste-code' : 'paste-text';
     tokens.push({ start: match.index ?? 0, end: (match.index ?? 0) + match[0].length, kind });
   }
-  // Skill tokens: [Skill #cavecrew] — expanded into a skill instruction on send.
-  for (const match of text.matchAll(/\[Skill #[^\]]+\]/g)) {
+  // Skill token: /skill (×1) or /skills #N (×N) — expanded into skill instructions on send.
+  for (const match of text.matchAll(/\/skills #\d+|\/skill(?!s)/g)) {
     tokens.push({ start: match.index ?? 0, end: (match.index ?? 0) + match[0].length, kind: 'skill' });
   }
   // @mention: '@' followed by any non-whitespace chars, must be preceded by whitespace or start of string

--- a/src/clihub/webview/ui/panel-terminal/tools-cli-ui/tools.ts
+++ b/src/clihub/webview/ui/panel-terminal/tools-cli-ui/tools.ts
@@ -1,6 +1,6 @@
 import { mountKeymapsPanel } from './modal-keymaps/keymaps';
 import { mountPromptPanel } from './modal-prompt/prompt';
-import type { ImageAttachment, PromptTranslateRequest, PromptTranslateResult, FileMentionEntry, SpellIssue } from '../../../core/tools-cli-core/prompt';
+import type { ImageAttachment, PromptTranslateRequest, PromptTranslateResult, FileMentionEntry, SpellIssue, WorkspaceSkill } from '../../../core/tools-cli-core/prompt';
 import type { VoiceState } from '../../../core/tools-cli-core/modal-voice/voice-types';
 import { mountTranslatorPanel } from './modal-translator/translator';
 
@@ -15,7 +15,7 @@ export type ToolContext = {
 	getTerminalSelection?: () => string;
 	preparePromptWithAttachments?: (text: string, attachments: ImageAttachment[]) => Promise<string>;
 	requestWorkspaceFiles?: () => Promise<FileMentionEntry[]>;
-	requestWorkspaceSkills?: () => Promise<string[]>;
+	requestWorkspaceSkills?: () => Promise<WorkspaceSkill[]>;
 	requestSpellcheck?: (text: string, strict: boolean) => Promise<SpellIssue[]>;
 	speakText?: (text: string) => void;
 	stopSpeech?: () => void;
@@ -33,7 +33,7 @@ export type ToolsControllerOptions = {
 	getTerminalSelection?: () => string;
 	preparePromptWithAttachments?: (text: string, attachments: ImageAttachment[]) => Promise<string>;
 	requestWorkspaceFiles?: () => Promise<FileMentionEntry[]>;
-	requestWorkspaceSkills?: () => Promise<string[]>;
+	requestWorkspaceSkills?: () => Promise<WorkspaceSkill[]>;
 	requestSpellcheck?: (text: string, strict: boolean) => Promise<SpellIssue[]>;
 	speakText?: (text: string) => void;
 	stopSpeech?: () => void;


### PR DESCRIPTION
This pull request introduces comprehensive support for workspace skills in the CLI prompt, allowing users to select skills from both `.agents/skills` and `.claude/skills` directories. Skills are now represented as a single aggregate token in the prompt textarea, which is expanded into explicit instructions with resolved SKILL.md paths upon sending. The changes also ensure skill tokens are protected during translation, improve marker handling, and update the UI for better skill chip interaction.

**Workspace Skills Infrastructure:**

- Added `WorkspaceSkill` and `SkillRoot` types, and logic to deduplicate and enumerate skills from `.agents/skills` and `.claude/skills`, surfacing them to the webview with all roots they exist in. The webview can now resolve the correct SKILL.md path per active CLI. (`src/clihub/main.ts`, `src/clihub/webview/core/tools-cli-core/prompt/skills.ts`, [[1]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4L20-R20) [[2]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4L244-R255) [[3]](diffhunk://#diff-effa457655274e027d43ab73a222a27ff750af6b5928d7f46986418f773ad0b4L273-R290) [[4]](diffhunk://#diff-905d853ac7abcf782b7783dab03df4aa1fa1b7d637d333e5c83b25109c9b3db3R1-R64)
- Updated the server/webview protocol and context to pass full `WorkspaceSkill` objects (not just names) for accurate skill selection and expansion. (`src/clihub/webview/ui/panel-terminal/terminal.ts`, `src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts`, [[1]](diffhunk://#diff-74bfb6e2f596b2e5f1d929921f430dc772c7ba9812da85417fb2067c582e06cdL52-R52) [[2]](diffhunk://#diff-74bfb6e2f596b2e5f1d929921f430dc772c7ba9812da85417fb2067c582e06cdL313-R316) [[3]](diffhunk://#diff-4de9b4566fbbfeadb336115f0c5645afa244230a1e92db9235d566a4c834e09aL80-R86)

**Prompt Token Handling and Expansion:**

- Introduced new token patterns and helper functions to protect, restore, and expand skill tokens (`/skills #N`, `/skill`, `[Skills #N]`) during translation, ensuring they are not altered and are expanded post-translation into explicit usage instructions with resolved SKILL.md paths. (`src/clihub/webview/core/tools-cli-core/prompt/attachments/markers.ts`, `src/clihub/webview/core/tools-cli-core/prompt/skills.ts`, [[1]](diffhunk://#diff-8f40d1a25d344d39c2e42f18db5bc1efadf147179b4dbe42dd2e4ea291dd706dL10-R45) [[2]](diffhunk://#diff-8f40d1a25d344d39c2e42f18db5bc1efadf147179b4dbe42dd2e4ea291dd706dR2) [[3]](diffhunk://#diff-c32ba1f6ca7ee0707a073d024c731024f01d93b48c203ab35096f284ba9e7edcR16-R28) [[4]](diffhunk://#diff-4de9b4566fbbfeadb336115f0c5645afa244230a1e92db9235d566a4c834e09aL272-R287) [[5]](diffhunk://#diff-4de9b4566fbbfeadb336115f0c5645afa244230a1e92db9235d566a4c834e09aR314-L317)

**UI/UX Improvements:**

- Updated the prompt UI to display skill chips, show an aggregate `/skills #N` token in the textarea, and visually highlight selected skills with numbered badges and consistent coloring, improving clarity and interaction. (`src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.css`, `src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/components/prompt.html`, [[1]](diffhunk://#diff-ebdae3cbe65f7fb561f33b146f2bcacd5f79777aa89c0a48c63f9636c4e8b194R572-R622) [[2]](diffhunk://#diff-ebdae3cbe65f7fb561f33b146f2bcacd5f79777aa89c0a48c63f9636c4e8b194L699-R750) [[3]](diffhunk://#diff-8703d7a80bf9a45ed7e955892dc2747daad874ec0ef8d5940fdc6fd47426bc81L58-R59)

**Spellcheck and Marker Patterns:**

- Extended the spellcheck protection pattern to exclude skill tokens from being flagged, ensuring they are not incorrectly marked as spelling issues. (`src/clihub/webview/core/tools-cli-core/autocorrect/host-spellcheck.ts`, [src/clihub/webview/core/tools-cli-core/autocorrect/host-spellcheck.tsL16-R16](diffhunk://#diff-f5e5926f0dcd634ef8a017e3ae79fd8261d3ce73ccb71aa2fc02340af4c142edL16-R16))
- Updated marker patterns and prompt logic to treat skill tokens as atomic units for navigation and deletion, aligning their behavior with image and paste markers. (`src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.ts`, [src/clihub/webview/ui/panel-terminal/tools-cli-ui/modal-prompt/prompt.tsL47-R55](diffhunk://#diff-4de9b4566fbbfeadb336115f0c5645afa244230a1e92db9235d566a4c834e09aL47-R55))

These changes collectively provide a robust, user-friendly way to manage and utilize workspace skills in the CLI prompt workflow.