### PR TITLE
Enhance modal tools with usage tracking, UI improvements, and shortcuts

### DIFF
--- a/src/clihub/host/workspace.ts
+++ b/src/clihub/host/workspace.ts
@@ -8,6 +8,15 @@ import * as vscode from 'vscode';
 import type { SkillRoot, WorkspaceSkill } from '../shared/prompt';
 import type { InboundWebviewMessage } from '../shared/protocol';
 
+type GitignoreRule = {
+	negated: boolean;
+	directoryOnly: boolean;
+	anchored: boolean;
+	hasSlash: boolean;
+	regexSource: string;
+	segmentRegex?: RegExp;
+};
+
 const visibleRootDotfiles = new Set([
 	'.babelrc',
 	'.browserslistrc',
@@ -99,6 +108,7 @@ export const handleWorkspaceListFiles = async (webview: vscode.Webview, message:
 		// Find files excluding common ignored directories
 		const uris = await vscode.workspace.findFiles('**/*', '{**/node_modules/**,**/.git/**,**/dist/**,**/out/**}', 1000);
 		const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+		const gitignoreRules = await getWorkspaceGitignoreRules(workspaceFolder);
 
 		const files = uris.map(uri => {
 			const isDirectory = false; // findFiles only returns files
@@ -117,7 +127,7 @@ export const handleWorkspaceListFiles = async (webview: vscode.Webview, message:
 				displayPath: getMentionDisplayPath(relativePath),
 				isDirectory
 			};
-		}).filter(entry => isMentionVisiblePath(entry.path));
+		}).filter(entry => isMentionVisiblePath(entry.path) && !isGitignoredPath(entry.path, entry.isDirectory, gitignoreRules));
 
 		// If we also want directories, we could get unique directory paths from the files list
 		const dirs = new Set<string>();
@@ -135,6 +145,10 @@ export const handleWorkspaceListFiles = async (webview: vscode.Webview, message:
 
 		const allEntries = [...files];
 		dirs.forEach(dir => {
+			if (isGitignoredPath(dir, true, gitignoreRules)) {
+				return;
+			}
+
 			allEntries.push({
 				name: path.basename(dir),
 				path: dir,
@@ -171,6 +185,159 @@ function isMentionVisiblePath(relativePath: string): boolean {
 
 		return index === segments.length - 1 && visibleRootDotfiles.has(segment);
 	});
+}
+
+async function getWorkspaceGitignoreRules(workspaceFolder: vscode.WorkspaceFolder | undefined): Promise<GitignoreRule[]> {
+	if (!workspaceFolder) {
+		return [];
+	}
+
+	try {
+		const gitignoreUri = vscode.Uri.joinPath(workspaceFolder.uri, '.gitignore');
+		const content = Buffer.from(await vscode.workspace.fs.readFile(gitignoreUri)).toString('utf8');
+		return parseGitignoreRules(content);
+	} catch {
+		return [];
+	}
+}
+
+function parseGitignoreRules(content: string): GitignoreRule[] {
+	return content
+		.split(/\r?\n/)
+		.map(parseGitignoreRule)
+		.filter((rule): rule is GitignoreRule => Boolean(rule));
+}
+
+function parseGitignoreRule(line: string): GitignoreRule | undefined {
+	let pattern = line.replace(/\s+$/, '');
+	if (!pattern) {
+		return undefined;
+	}
+
+	if (pattern.startsWith('\\#')) {
+		pattern = pattern.slice(1);
+	} else if (pattern.startsWith('#')) {
+		return undefined;
+	}
+
+	let negated = false;
+	if (pattern.startsWith('\\!')) {
+		pattern = pattern.slice(1);
+	} else if (pattern.startsWith('!')) {
+		negated = true;
+		pattern = pattern.slice(1);
+	}
+
+	const anchored = pattern.startsWith('/');
+	pattern = pattern.replace(/^\/+/, '');
+
+	const directoryOnly = pattern.endsWith('/');
+	pattern = pattern.replace(/\/+$/, '');
+	if (!pattern) {
+		return undefined;
+	}
+
+	const hasSlash = pattern.includes('/');
+	const regexSource = gitignoreGlobToRegexSource(pattern);
+
+	return {
+		negated,
+		directoryOnly,
+		anchored,
+		hasSlash,
+		regexSource,
+		segmentRegex: hasSlash ? undefined : new RegExp(`^${regexSource}$`),
+	};
+}
+
+function isGitignoredPath(relativePath: string, isDirectory: boolean, rules: GitignoreRule[]): boolean {
+	if (rules.length === 0) {
+		return false;
+	}
+
+	const normalizedPath = normalizeRelativePath(relativePath);
+	if (!normalizedPath) {
+		return false;
+	}
+
+	let ignored = false;
+	for (const rule of rules) {
+		if (matchesGitignoreRule(rule, normalizedPath, isDirectory)) {
+			ignored = !rule.negated;
+		}
+	}
+
+	return ignored;
+}
+
+function matchesGitignoreRule(rule: GitignoreRule, relativePath: string, isDirectory: boolean): boolean {
+	if (!rule.hasSlash && rule.segmentRegex) {
+		const segments = relativePath.split('/').filter(Boolean);
+		if (rule.anchored) {
+			const [rootSegment] = segments;
+			if (!rootSegment || !rule.segmentRegex.test(rootSegment)) {
+				return false;
+			}
+
+			if (!rule.directoryOnly) {
+				return true;
+			}
+
+			return isDirectory || segments.length > 1;
+		}
+
+		return segments.some((segment, index) => {
+			if (!rule.segmentRegex?.test(segment)) {
+				return false;
+			}
+
+			if (!rule.directoryOnly) {
+				return true;
+			}
+
+			return isDirectory || index < segments.length - 1;
+		});
+	}
+
+	const matchPrefix = rule.anchored ? '^' : '(?:^|/)';
+	return new RegExp(`${matchPrefix}${rule.regexSource}(?:/.*)?$`).test(relativePath);
+}
+
+function normalizeRelativePath(relativePath: string): string {
+	return relativePath.replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+function gitignoreGlobToRegexSource(pattern: string): string {
+	let source = '';
+
+	for (let index = 0; index < pattern.length; index += 1) {
+		const char = pattern[index];
+
+		if (char === '*') {
+			const isDoubleStar = pattern[index + 1] === '*';
+			if (isDoubleStar) {
+				const consumesSlash = pattern[index + 2] === '/';
+				source += consumesSlash ? '(?:.*\\/)?' : '.*';
+				index += consumesSlash ? 2 : 1;
+			} else {
+				source += '[^/]*';
+			}
+			continue;
+		}
+
+		if (char === '?') {
+			source += '[^/]';
+			continue;
+		}
+
+		source += escapeRegexChar(char);
+	}
+
+	return source;
+}
+
+function escapeRegexChar(char: string): string {
+	return /[|\\{}()[\]^$+?.]/.test(char) ? `\\${char}` : char;
 }
 
 function getMentionDisplayPath(relativePath: string): string {

--- a/src/clihub/webview/keymaps.ts
+++ b/src/clihub/webview/keymaps.ts
@@ -22,7 +22,8 @@ export type ShortcutId =
   | 'closeLauncherPalette' // launcher only
   | 'openPrompt'           // opens the Prompt tool modal
   | 'openTranslate'        // opens the Translate tool modal
-  | 'openKeymaps';         // opens the Keymaps tool modal
+  | 'openKeymaps'          // opens the Keymaps tool modal
+  | 'openUse';             // opens the Status/use tool modal
 
 export interface ShortcutDefinition {
   id: ShortcutId;
@@ -220,6 +221,13 @@ export const shortcuts: ShortcutDefinition[] = [
     contexts: ['terminal'],
     description: 'Shift + F3',
     match: shiftFKey(3),
+  },
+  {
+    id: 'openUse',
+    label: 'Open Status/use tool',
+    contexts: ['terminal'],
+    description: 'Shift + F4',
+    match: shiftFKey(4),
   },
 
   {

--- a/src/clihub/webview/keymaps.ts
+++ b/src/clihub/webview/keymaps.ts
@@ -219,15 +219,15 @@ export const shortcuts: ShortcutDefinition[] = [
     id: 'openKeymaps',
     label: 'Open Keymaps tool',
     contexts: ['terminal'],
-    description: 'Shift + F3',
-    match: shiftFKey(3),
+    description: 'Shift + F4',
+    match: shiftFKey(4),
   },
   {
     id: 'openUse',
     label: 'Open Status/use tool',
     contexts: ['terminal'],
-    description: 'Shift + F4',
-    match: shiftFKey(4),
+    description: 'Shift + F3',
+    match: shiftFKey(3),
   },
 
   {

--- a/src/clihub/webview/panel-tab/tab.css
+++ b/src/clihub/webview/panel-tab/tab.css
@@ -867,6 +867,39 @@
 		transform: translateY(-1px);
 	}
 
+	.agent-session-list.is-alt-close-mode .agent-session-item:hover {
+		cursor: pointer;
+	}
+
+	.agent-session-list.is-alt-close-mode .agent-session-item:hover .agent-session-icon-frame {
+		border-color: #ef4444;
+		background: color-mix(in srgb, #ef4444 20%, var(--vscode-input-background, rgba(128, 128, 128, 0.08)));
+		box-shadow:
+			0 5px 14px rgba(0, 0, 0, 0.34),
+			0 0 0 1px #ef4444,
+			0 0 0 5px color-mix(in srgb, #ef4444 18%, transparent);
+	}
+
+	.agent-session-list.is-alt-close-mode .agent-session-item:hover .agent-session-icon-image {
+		opacity: 0.28;
+		transform: scale(0.82);
+	}
+
+	.agent-session-list.is-alt-close-mode .agent-session-item:hover .agent-session-icon-frame::before {
+		content: 'x';
+		position: absolute;
+		inset: 0;
+		z-index: 3;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		color: #fecaca;
+		font-size: 18px;
+		font-weight: 700;
+		line-height: 1;
+		text-shadow: 0 1px 4px rgba(0, 0, 0, 0.42);
+	}
+
 	/* === Active state - more visible "new selection" effect === */
 	.agent-session-item.is-active .agent-session-icon-frame {
 		border: 1.5px solid var(--vscode-focusBorder, var(--vscode-textLink-foreground));

--- a/src/clihub/webview/panel-tab/tab.css
+++ b/src/clihub/webview/panel-tab/tab.css
@@ -741,8 +741,9 @@
 
 	.agent-tools-popover {
 		z-index: 100;
-		top: 37px;
+		top: 46px;
 		right: 10px;
+		padding: 7px 0;
 	}
 
 	.agent-picker-menu {

--- a/src/clihub/webview/panel-tab/tab.html
+++ b/src/clihub/webview/panel-tab/tab.html
@@ -71,6 +71,14 @@
 					<span class="agent-tools-item-shortcut">shift+f3</span>
 				</button>
 
+				<button class="agent-tools-item" type="button" role="menuitem" data-tool="use">
+					<span class="agent-tools-item-icon" aria-hidden="true">U</span>
+					<span class="agent-tools-item-text">Status/use</span>
+					<span class="agent-tools-item-shortcut">shift+f4</span>
+				</button>
+
+				<div class="agent-tools-divider"></div>
+
 				<label class="agent-tools-toggle">
 					<span class="agent-tools-toggle-copy">
 						<span class="agent-tools-toggle-title">Filter (P... / T...)</span>

--- a/src/clihub/webview/panel-tab/tab.ts
+++ b/src/clihub/webview/panel-tab/tab.ts
@@ -269,6 +269,7 @@ export const createTabController = (options: TabControllerOptions) => {
 		} else {
 			createButtonLabel.textContent = currentSessionCount >= 3 && currentSessionCount <= 9 ? String(currentSessionCount) : '+';
 		}
+		sessionList.classList.toggle('is-alt-close-mode', isAltPressed);
 	};
 
 	const updateCreateButtonLabel = (sessionCount: number) => {
@@ -366,6 +367,19 @@ export const createTabController = (options: TabControllerOptions) => {
 	});
 
 	createButton.addEventListener('mouseleave', () => {
+		updateCreateButtonVisuals();
+	});
+
+	sessionList.addEventListener('mouseenter', (event) => {
+		isAltPressed = event.altKey;
+		updateCreateButtonVisuals();
+	});
+
+	sessionList.addEventListener('mousemove', (event) => {
+		if (event.altKey === isAltPressed) {
+			return;
+		}
+		isAltPressed = event.altKey;
 		updateCreateButtonVisuals();
 	});
 
@@ -654,15 +668,19 @@ export const createTabController = (options: TabControllerOptions) => {
 				}
 			});
 
-			const switchSession = () => {
+			const switchSession = (event?: MouseEvent | KeyboardEvent) => {
 				dismissToolModal();
+				if (event?.altKey || isAltPressed) {
+					options.onClose(session.id);
+					return;
+				}
 				options.onSwitch(session.id);
 			};
 			item.addEventListener('click', switchSession);
 			item.addEventListener('keydown', (event) => {
 				if (event.key === 'Enter' || event.key === ' ') {
 					event.preventDefault();
-					switchSession();
+					switchSession(event);
 				}
 			});
 

--- a/src/clihub/webview/panel-tab/tab.ts
+++ b/src/clihub/webview/panel-tab/tab.ts
@@ -20,7 +20,7 @@ export type CliSessionSummary = {
 
 import { consumeShortcut, matchesShortcut } from '../keymaps';
 
-export type CliToolId = 'translate' | 'keymaps' | 'prompt';
+export type CliToolId = 'translate' | 'keymaps' | 'prompt' | 'use';
 
 type TabControllerOptions = {
 	getAgentIcon: (label: string) => CliAgentIcon | undefined;
@@ -326,6 +326,12 @@ export const createTabController = (options: TabControllerOptions) => {
 				return true;
 			}
 		}
+		if (matchesShortcut(event, 'openUse')) {
+			if (consumeShortcut(event, 'openUse')) {
+				options.onOpenTool?.('use');
+				return true;
+			}
+		}
 
 		const action = getShortcutAction(event);
 		if (!action) {
@@ -456,7 +462,7 @@ export const createTabController = (options: TabControllerOptions) => {
 		const target = event.target instanceof HTMLElement ? event.target : null;
 		const toolButton = target?.closest<HTMLButtonElement>('[data-tool]');
 		const tool = toolButton?.dataset.tool;
-		if (tool === 'translate' || tool === 'keymaps' || tool === 'prompt') {
+		if (tool === 'translate' || tool === 'keymaps' || tool === 'prompt' || tool === 'use') {
 			setToolsPopoverOpen(false);
 			options.onOpenTool?.(tool);
 		}

--- a/src/clihub/webview/panel-terminal/terminal.css
+++ b/src/clihub/webview/panel-terminal/terminal.css
@@ -105,6 +105,17 @@
 	display: flex;
 }
 
+/* Prevent ugly focus rings (yellow/orange outlines in many themes) on the
+   terminal area. We use Terminal.focus() on the xterm instance for proper
+   input activation; the internal helper textarea is styled by xterm to be
+   invisible. These rules are defensive in case a container div ever receives
+   focus directly (e.g. from tool modal close or other keyboard flows). */
+.cli-terminal-pane:focus,
+.cli-terminal-pane:focus-visible {
+	outline: none !important;
+	box-shadow: none;
+}
+
 @media (max-width: 640px), (orientation: portrait) {
 	.layout-right {
 		min-height: 0;

--- a/src/clihub/webview/panel-terminal/terminal.ts
+++ b/src/clihub/webview/panel-terminal/terminal.ts
@@ -52,6 +52,7 @@ const usageRequestSettleDelayMs = 900;
 const usageRequestTimeoutMs = 7000;
 const usageDismissSecondEscapeDelayMs = 80;
 const usageCommandsByAgentSlug: Record<string, string> = {
+	claude: '/usage',
 	kiro: '/usage'
 };
 let activeSessionId: string | undefined;

--- a/src/clihub/webview/panel-terminal/terminal.ts
+++ b/src/clihub/webview/panel-terminal/terminal.ts
@@ -519,6 +519,20 @@ const toolsController = layoutRight
 				// TUI CLIs never produce an xterm selection — fall back to the
 				// text they copied (captured via OSC 52 or the clipboard watch).
 				return selection || copyToTranslate.getLastCopiedText();
+			},
+			refocusTerminal: () => {
+				if (activeSessionId) {
+					const view = terminals.get(activeSessionId);
+					if (view?.terminal) {
+						// Use the real xterm instance focus — it moves input focus to the
+						// internal helper textarea (which is hidden and has no visible ring).
+						view.terminal.focus();
+						return;
+					}
+				}
+				// Fallback (very rare): at least put focus near the terminal area.
+				const activePane = document.querySelector<HTMLElement>('.cli-terminal-pane.is-active');
+				activePane?.focus();
 			}
 		})
 	: undefined;

--- a/src/clihub/webview/panel-terminal/terminal.ts
+++ b/src/clihub/webview/panel-terminal/terminal.ts
@@ -3,7 +3,7 @@ import { Terminal } from '@xterm/xterm';
 import { createTabController, type CliAgentIcon } from '../panel-tab/tab';
 import { createCliCreateMessage } from '../../shared/agent-launch-guard';
 import { getAgentSlug as resolveAgentSlug } from '../../shared/agents';
-import { createToolsController } from '../tools/tools';
+import { createToolsController, type CliUsageSnapshot } from '../tools/tools';
 import { detectModelName } from '../../shared/model-detect';
 import { createRpcChannel } from './host-rpc';
 import { createBootSkeletons } from './boot-skeleton';
@@ -48,9 +48,25 @@ const defaultSubmitDelayMs = 150;
 const slowPasteSubmitDelayMs = 750;
 const routeSubmitDelayMs = 450;
 const routeSubmitSecondEnterDelayMs = 350;
+const usageRequestSettleDelayMs = 900;
+const usageRequestTimeoutMs = 7000;
+const usageCommandsByAgentSlug: Record<string, string> = {
+	kiro: '/usage'
+};
 let activeSessionId: string | undefined;
 let pendingTabSwitchSessionId: string | undefined;
 let isPromptFilterEnabled = false;
+const usageSnapshots = new Map<string, CliUsageSnapshot>();
+let pendingUsageRequest: {
+	sessionId: string;
+	agentLabel: string;
+	command: string;
+	startBufferLength: number;
+	resolve: (snapshot: CliUsageSnapshot) => void;
+	reject: (reason?: unknown) => void;
+	settleTimer?: number;
+	timeoutTimer?: number;
+} | undefined;
 
 const isAgentIcon = (value: unknown): value is CliAgentIcon => {
 	if (!value || typeof value !== 'object') {
@@ -176,6 +192,89 @@ const getSubmitDelayMs = (agentSlug: string, text: string) => {
 
 	return defaultSubmitDelayMs;
 };
+
+const getUsageCommandForAgent = (agentLabel: string) => {
+	const slug = resolveAgentSlug(agentLabel) ?? 'default';
+	return usageCommandsByAgentSlug[slug];
+};
+
+const clearPendingUsageRequest = () => {
+	if (!pendingUsageRequest) {
+		return;
+	}
+
+	window.clearTimeout(pendingUsageRequest.settleTimer);
+	window.clearTimeout(pendingUsageRequest.timeoutTimer);
+	pendingUsageRequest = undefined;
+};
+
+const resolvePendingUsageRequest = () => {
+	const request = pendingUsageRequest;
+	if (!request) {
+		return;
+	}
+
+	const session = sessions.get(request.sessionId);
+	const raw = session?.buffer.slice(request.startBufferLength) ?? '';
+	const snapshot: CliUsageSnapshot = {
+		sessionId: request.sessionId,
+		agentLabel: request.agentLabel,
+		command: request.command,
+		raw,
+		requestedAt: Date.now()
+	};
+
+	usageSnapshots.set(request.sessionId, snapshot);
+	clearPendingUsageRequest();
+	request.resolve(snapshot);
+};
+
+const schedulePendingUsageSettle = (sessionId: string) => {
+	if (!pendingUsageRequest || pendingUsageRequest.sessionId !== sessionId) {
+		return;
+	}
+
+	window.clearTimeout(pendingUsageRequest.settleTimer);
+	pendingUsageRequest.settleTimer = window.setTimeout(resolvePendingUsageRequest, usageRequestSettleDelayMs);
+};
+
+const requestActiveUsage = () => new Promise<CliUsageSnapshot>((resolve, reject) => {
+	if (!activeSessionId) {
+		reject(new Error('No active CLI session.'));
+		return;
+	}
+
+	const session = sessions.get(activeSessionId);
+	if (!session || session.status !== 'running') {
+		reject(new Error('The active CLI session is not running.'));
+		return;
+	}
+
+	const command = getUsageCommandForAgent(session.label);
+	if (!command) {
+		reject(new Error(`Usage command is not configured for ${session.label}.`));
+		return;
+	}
+
+	if (pendingUsageRequest) {
+		pendingUsageRequest.reject(new Error('Usage refresh was superseded.'));
+		clearPendingUsageRequest();
+	}
+
+	const view = terminals.get(session.id);
+	const data = view?.terminal.modes.sendFocusMode ? `\x1b[I${command}\r` : `${command}\r`;
+	pendingUsageRequest = {
+		sessionId: session.id,
+		agentLabel: session.label,
+		command,
+		startBufferLength: session.buffer.length,
+		resolve,
+		reject,
+		timeoutTimer: window.setTimeout(resolvePendingUsageRequest, usageRequestTimeoutMs)
+	};
+
+	vscode.postMessage({ type: 'cli.input', sessionId: session.id, data });
+});
 
 // ── Host round-trips ─────────────────────────────────────────────────
 // One RPC channel per request/response message pair; see host-rpc.ts.
@@ -322,6 +421,13 @@ const toolsController = layoutRight
 				}
 				return detectModelName(getAgentSlug(session.label), session.buffer);
 			},
+			getUsageSnapshot: () => {
+				if (!activeSessionId) {
+					return undefined;
+				}
+				return usageSnapshots.get(activeSessionId);
+			},
+			requestUsage: requestActiveUsage,
 			sendToActiveSession: (text: string, options?: { paste?: boolean; submit?: boolean }) => {
 				if (!activeSessionId) {
 					return;
@@ -678,6 +784,15 @@ const syncState = (message: Extract<ServerMessage, { type: 'cli.state' }>) => {
 
 	removeClosedTerminals(openSessionIds);
 	sleepInactiveTerminals(visualSleepEnabled, openSessionIds);
+	for (const sessionId of [...usageSnapshots.keys()]) {
+		if (!openSessionIds.has(sessionId)) {
+			usageSnapshots.delete(sessionId);
+		}
+	}
+	if (pendingUsageRequest && !openSessionIds.has(pendingUsageRequest.sessionId)) {
+		pendingUsageRequest.reject(new Error('Usage refresh session was closed.'));
+		clearPendingUsageRequest();
+	}
 
 	// If a session entered error/exited state before producing output, don't leave skeleton hanging
 	for (const [sessionId, session] of sessions) {
@@ -694,6 +809,7 @@ const handleOutput = (message: Extract<ServerMessage, { type: 'cli.output' }>) =
 	const session = sessions.get(message.sessionId);
 	if (session) {
 		appendToSessionBuffer(session, message.data);
+		schedulePendingUsageSettle(message.sessionId);
 	}
 
 	let restoredFromBuffer = false;

--- a/src/clihub/webview/panel-terminal/terminal.ts
+++ b/src/clihub/webview/panel-terminal/terminal.ts
@@ -50,6 +50,7 @@ const routeSubmitDelayMs = 450;
 const routeSubmitSecondEnterDelayMs = 350;
 const usageRequestSettleDelayMs = 900;
 const usageRequestTimeoutMs = 7000;
+const usageDismissSecondEscapeDelayMs = 80;
 const usageCommandsByAgentSlug: Record<string, string> = {
 	kiro: '/usage'
 };
@@ -276,6 +277,29 @@ const requestActiveUsage = () => new Promise<CliUsageSnapshot>((resolve, reject)
 	vscode.postMessage({ type: 'cli.input', sessionId: session.id, data });
 });
 
+const dismissActiveUsageView = () => {
+	if (!activeSessionId) {
+		return;
+	}
+
+	const sessionId = activeSessionId;
+	const session = sessions.get(sessionId);
+	if (session?.status !== 'running') {
+		return;
+	}
+
+	const view = terminals.get(sessionId);
+	const data = view?.terminal.modes.sendFocusMode ? '\x1b[I\x1b' : '\x1b';
+	const postEscape = () => {
+		if (sessions.get(sessionId)?.status === 'running') {
+			vscode.postMessage({ type: 'cli.input', sessionId, data });
+		}
+	};
+
+	postEscape();
+	window.setTimeout(postEscape, usageDismissSecondEscapeDelayMs);
+};
+
 // ── Host round-trips ─────────────────────────────────────────────────
 // One RPC channel per request/response message pair; see host-rpc.ts.
 
@@ -428,6 +452,7 @@ const toolsController = layoutRight
 				return usageSnapshots.get(activeSessionId);
 			},
 			requestUsage: requestActiveUsage,
+			dismissUsageView: dismissActiveUsageView,
 			sendToActiveSession: (text: string, options?: { paste?: boolean; submit?: boolean }) => {
 				if (!activeSessionId) {
 					return;

--- a/src/clihub/webview/panel-terminal/terminal.ts
+++ b/src/clihub/webview/panel-terminal/terminal.ts
@@ -53,6 +53,7 @@ const usageRequestTimeoutMs = 7000;
 const usageDismissSecondEscapeDelayMs = 80;
 const codexUsageSubmitDelayMs = 150;
 const usageCommandsByAgentSlug: Record<string, string> = {
+	antigravity: '/usage',
 	claude: '/usage',
 	codex: '/status',
 	kiro: '/usage'

--- a/src/clihub/webview/panel-terminal/terminal.ts
+++ b/src/clihub/webview/panel-terminal/terminal.ts
@@ -306,6 +306,12 @@ const toolsController = layoutRight
 	? createToolsController({
 			container: layoutRight,
 			getActiveSessionId: () => activeSessionId,
+			getActiveSessionCreatedAt: () => {
+				if (!activeSessionId) {
+					return undefined;
+				}
+				return sessions.get(activeSessionId)?.createdAt;
+			},
 			getActiveModelName: () => {
 				if (!activeSessionId) {
 					return undefined;

--- a/src/clihub/webview/panel-terminal/terminal.ts
+++ b/src/clihub/webview/panel-terminal/terminal.ts
@@ -51,8 +51,10 @@ const routeSubmitSecondEnterDelayMs = 350;
 const usageRequestSettleDelayMs = 900;
 const usageRequestTimeoutMs = 7000;
 const usageDismissSecondEscapeDelayMs = 80;
+const codexUsageSubmitDelayMs = 150;
 const usageCommandsByAgentSlug: Record<string, string> = {
 	claude: '/usage',
+	codex: '/status',
 	kiro: '/usage'
 };
 let activeSessionId: string | undefined;
@@ -200,6 +202,10 @@ const getUsageCommandForAgent = (agentLabel: string) => {
 	return usageCommandsByAgentSlug[slug];
 };
 
+const getUsageInputData = (view: TerminalView | undefined, data: string) => (
+	view?.terminal.modes.sendFocusMode ? `\x1b[I${data}` : data
+);
+
 const clearPendingUsageRequest = () => {
 	if (!pendingUsageRequest) {
 		return;
@@ -264,7 +270,7 @@ const requestActiveUsage = () => new Promise<CliUsageSnapshot>((resolve, reject)
 	}
 
 	const view = terminals.get(session.id);
-	const data = view?.terminal.modes.sendFocusMode ? `\x1b[I${command}\r` : `${command}\r`;
+	const agentSlug = getAgentSlug(session.label);
 	pendingUsageRequest = {
 		sessionId: session.id,
 		agentLabel: session.label,
@@ -275,7 +281,29 @@ const requestActiveUsage = () => new Promise<CliUsageSnapshot>((resolve, reject)
 		timeoutTimer: window.setTimeout(resolvePendingUsageRequest, usageRequestTimeoutMs)
 	};
 
-	vscode.postMessage({ type: 'cli.input', sessionId: session.id, data });
+	if (agentSlug === 'codex') {
+		vscode.postMessage({
+			type: 'cli.input',
+			sessionId: session.id,
+			data: getUsageInputData(view, command)
+		});
+		window.setTimeout(() => {
+			if (sessions.get(session.id)?.status === 'running') {
+				vscode.postMessage({
+					type: 'cli.input',
+					sessionId: session.id,
+					data: getUsageInputData(view, '\r')
+				});
+			}
+		}, codexUsageSubmitDelayMs);
+		return;
+	}
+
+	vscode.postMessage({
+		type: 'cli.input',
+		sessionId: session.id,
+		data: getUsageInputData(view, `${command}\r`)
+	});
 });
 
 const dismissActiveUsageView = () => {

--- a/src/clihub/webview/tools/modal-keymaps/components/keys.css
+++ b/src/clihub/webview/tools/modal-keymaps/components/keys.css
@@ -3,6 +3,7 @@
 	max-height: min(560px, calc(100vh - 32px));
 	display: flex;
 	flex-direction: column;
+	position: relative;
 	box-sizing: border-box;
 	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.35));
 	border-radius: 8px;
@@ -14,11 +15,38 @@
 	overflow: hidden;
 }
 
+.keymaps-modal::before {
+	content: '';
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 1px;
+	background: linear-gradient(
+		90deg,
+		transparent 0%,
+		var(--vscode-focusBorder, var(--vscode-textLink-foreground, #007acc)) 32%,
+		color-mix(in srgb, var(--vscode-focusBorder, var(--vscode-textLink-foreground, #007acc)) 65%, white) 68%,
+		transparent 100%
+	);
+	opacity: 0.62;
+	z-index: 10;
+	pointer-events: none;
+}
+
 /* Styles  keymap */
 .keymaps-header {
 	flex: 0 0 auto;
 	padding: 16px 20px 12px;
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
 	border-bottom: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.2));
+}
+
+.keymaps-header-copy {
+	min-width: 0;
 }
 
 .keymaps-title {
@@ -32,6 +60,26 @@
 	color: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72));
 	font-size: 11px;
 	line-height: 1.35;
+}
+
+.keymaps-close-btn {
+	flex: 0 0 auto;
+	border: none;
+	border-radius: 4px;
+	padding: 3px 6px;
+	background: transparent;
+	color: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72));
+	font-family: var(--vscode-editor-font-family, ui-monospace, monospace);
+	font-size: 11px;
+	line-height: 1;
+	cursor: pointer;
+}
+
+.keymaps-close-btn:hover,
+.keymaps-close-btn:focus-visible {
+	background: var(--vscode-toolbar-hoverBackground, rgba(128, 128, 128, 0.14));
+	color: var(--vscode-foreground);
+	outline: none;
 }
 
 .keymaps-content {

--- a/src/clihub/webview/tools/modal-keymaps/components/keys.html
+++ b/src/clihub/webview/tools/modal-keymaps/components/keys.html
@@ -95,7 +95,7 @@
 					<span class="keymap-label">Open Keymaps</span>
 				</div>
 				<div class="keymap-keys">
-					<kbd class="key">⇧</kbd><kbd class="key">F3</kbd>
+					<kbd class="key">⇧</kbd><kbd class="key">F4</kbd>
 				</div>
 			</div>
 
@@ -105,7 +105,7 @@
 					<span class="keymap-label">Open Status/use</span>
 				</div>
 				<div class="keymap-keys">
-					<kbd class="key">⇧</kbd><kbd class="key">F4</kbd>
+					<kbd class="key">⇧</kbd><kbd class="key">F3</kbd>
 				</div>
 			</div>
 

--- a/src/clihub/webview/tools/modal-keymaps/components/keys.html
+++ b/src/clihub/webview/tools/modal-keymaps/components/keys.html
@@ -1,7 +1,10 @@
 <div class="keymaps-modal">
 	<div class="keymaps-header">
-		<div class="keymaps-title">Keyboard Shortcuts</div>
-		<div class="keymaps-subtitle">Available while using CLI Hub</div>
+		<div class="keymaps-header-copy">
+			<div class="keymaps-title">Keyboard Shortcuts</div>
+			<div class="keymaps-subtitle">Available while using CLI Hub</div>
+		</div>
+		<button class="keymaps-close-btn" id="closeKeymapsBtn" type="button" aria-label="Close" title="Close (Esc)">esc</button>
 	</div>
 
 	<div class="keymaps-content">

--- a/src/clihub/webview/tools/modal-keymaps/components/keys.html
+++ b/src/clihub/webview/tools/modal-keymaps/components/keys.html
@@ -68,11 +68,41 @@
 
 			<div class="keymap-item">
 				<div class="keymap-left">
-					<span class="keymap-icon">T</span>
-					<span class="keymap-label">Open Translate</span>
+					<span class="keymap-icon">P</span>
+					<span class="keymap-label">Open Prompt</span>
 				</div>
 				<div class="keymap-keys">
 					<kbd class="key">⇧</kbd><kbd class="key">F1</kbd>
+				</div>
+			</div>
+
+			<div class="keymap-item">
+				<div class="keymap-left">
+					<span class="keymap-icon">T</span>
+					<span class="keymap-label">Open Translator</span>
+				</div>
+				<div class="keymap-keys">
+					<kbd class="key">⇧</kbd><kbd class="key">F2</kbd>
+				</div>
+			</div>
+
+			<div class="keymap-item">
+				<div class="keymap-left">
+					<span class="keymap-icon">K</span>
+					<span class="keymap-label">Open Keymaps</span>
+				</div>
+				<div class="keymap-keys">
+					<kbd class="key">⇧</kbd><kbd class="key">F3</kbd>
+				</div>
+			</div>
+
+			<div class="keymap-item">
+				<div class="keymap-left">
+					<span class="keymap-icon">U</span>
+					<span class="keymap-label">Open Status/use</span>
+				</div>
+				<div class="keymap-keys">
+					<kbd class="key">⇧</kbd><kbd class="key">F4</kbd>
 				</div>
 			</div>
 

--- a/src/clihub/webview/tools/modal-keymaps/keymaps.ts
+++ b/src/clihub/webview/tools/modal-keymaps/keymaps.ts
@@ -1,5 +1,6 @@
 import keysStyles from './components/keys.css';
 import keysHtml from './components/keys.html';
+import type { ToolContext } from '../tools';
 
 const stylesId = 'cli-keymaps-panel-styles';
 
@@ -14,10 +15,13 @@ const ensureStyles = () => {
 	document.head.append(style);
 };
 
-export const mountKeymapsPanel = (host: HTMLElement) => {
+export const mountKeymapsPanel = (host: HTMLElement, context: ToolContext) => {
 	ensureStyles();
 
 	const template = document.createElement('template');
 	template.innerHTML = (keysHtml as unknown as string).trim();
 	host.replaceChildren(template.content.cloneNode(true));
+
+	const closeBtn = host.querySelector<HTMLButtonElement>('#closeKeymapsBtn');
+	closeBtn?.addEventListener('click', () => context.close());
 };

--- a/src/clihub/webview/tools/modal-prompt/components/prompt.css
+++ b/src/clihub/webview/tools/modal-prompt/components/prompt.css
@@ -16,6 +16,7 @@
 /* Main container */
 .prompt-modal {
   width: min(500px, calc(100vw - 32px));
+  min-height: 0;
   background: var(--vscode-editor-background);
   border: 1px solid var(--vscode-editorGroup-border);
   border-radius: 14px;
@@ -442,7 +443,10 @@
 /* Body */
 .prompt-body {
   padding: 16px 20px;
-  flex: 0 0 auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  overscroll-behavior: contain;
 }
 
 .prompt-textarea-wrap {

--- a/src/clihub/webview/tools/modal-prompt/components/prompt.css
+++ b/src/clihub/webview/tools/modal-prompt/components/prompt.css
@@ -456,7 +456,7 @@
 .prompt-textarea {
   width: 100%;
   min-height: 100px;
-  max-height: min(520px, calc(100vh - 330px));
+  max-height: min(620px, calc(100vh - 300px));
   overflow-y: auto;
   background: var(--vscode-input-background);
   border: 0.5px solid var(--vscode-editorGroup-border);

--- a/src/clihub/webview/tools/modal-prompt/components/prompt.css
+++ b/src/clihub/webview/tools/modal-prompt/components/prompt.css
@@ -456,7 +456,7 @@
 .prompt-textarea {
   width: 100%;
   min-height: 100px;
-  max-height: calc(100vh - 260px);
+  max-height: min(520px, calc(100vh - 330px));
   overflow-y: auto;
   background: var(--vscode-input-background);
   border: 0.5px solid var(--vscode-editorGroup-border);

--- a/src/clihub/webview/tools/modal-translator/components/translator.css
+++ b/src/clihub/webview/tools/modal-translator/components/translator.css
@@ -5,6 +5,7 @@
 .translator-modal {
 	width: 100%;
 	max-height: 100%;
+	min-height: 0;
 	display: flex;
 	flex-direction: column;
 	box-sizing: border-box;
@@ -193,8 +194,10 @@
 
 /* ── Body ────────────────────────────────────────────────────────── */
 .translator-body {
-	flex: 0 1 auto;
+	flex: 1 1 auto;
+	min-height: 0;
 	overflow-y: auto;
+	overscroll-behavior: contain;
 	padding: 16px 18px;
 	scrollbar-width: thin;
 	scrollbar-color: rgba(175, 169, 236, 0.2) transparent;
@@ -748,4 +751,3 @@
 	border-color: color-mix(in srgb, var(--agent-accent) 25%, transparent);
 	color: var(--agent-accent);
 }
-

--- a/src/clihub/webview/tools/modal-use/components/use.css
+++ b/src/clihub/webview/tools/modal-use/components/use.css
@@ -1,6 +1,6 @@
 .use-modal {
-	width: min(520px, calc(100vw - 32px));
-	max-height: min(520px, calc(100vh - 32px));
+	width: min(430px, calc(100vw - 32px));
+	max-height: min(420px, calc(100vh - 32px));
 	display: flex;
 	flex-direction: column;
 	box-sizing: border-box;
@@ -158,7 +158,7 @@
 	line-height: 1.35;
 }
 
-.use-grid {
+.use-metrics {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
 	gap: 8px;
@@ -166,7 +166,7 @@
 
 .use-field {
 	min-width: 0;
-	min-height: 54px;
+	min-height: 68px;
 	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.2));
 	border-radius: 6px;
 	padding: 10px 11px;
@@ -178,8 +178,11 @@
 	background: var(--vscode-input-background, rgba(128, 128, 128, 0.08));
 }
 
-.use-field-wide {
-	grid-column: 1 / -1;
+.use-field-value-large {
+	font-family: var(--vscode-editor-font-family, ui-monospace, monospace);
+	font-size: 18px;
+	font-weight: 700;
+	letter-spacing: 0;
 }
 
 @media (max-width: 520px) {
@@ -192,7 +195,7 @@
 		padding: 14px 16px 10px;
 	}
 
-	.use-grid {
+	.use-metrics {
 		grid-template-columns: 1fr;
 	}
 }

--- a/src/clihub/webview/tools/modal-use/components/use.css
+++ b/src/clihub/webview/tools/modal-use/components/use.css
@@ -1,6 +1,6 @@
 .use-modal {
-	width: min(430px, calc(100vw - 32px));
-	max-height: min(360px, calc(100vh - 32px));
+	width: min(470px, calc(100vw - 32px));
+	max-height: min(400px, calc(100vh - 32px));
 	display: flex;
 	flex-direction: column;
 	position: relative;
@@ -251,6 +251,7 @@
 	padding: 10px;
 	box-sizing: border-box;
 	background: var(--vscode-input-background, rgba(128, 128, 128, 0.08));
+	min-height: 200px;
 }
 
 .use-usage-card.is-loading::after {
@@ -271,7 +272,7 @@
 }
 
 .use-usage-message {
-	min-height: 58px;
+	min-height: 160px;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
@@ -296,6 +297,8 @@
 	display: flex;
 	flex-direction: column;
 	gap: 10px;
+	opacity: 1;
+	transition: opacity 180ms ease;
 }
 
 .use-usage-result[hidden],

--- a/src/clihub/webview/tools/modal-use/components/use.css
+++ b/src/clihub/webview/tools/modal-use/components/use.css
@@ -3,6 +3,7 @@
 	max-height: min(360px, calc(100vh - 32px));
 	display: flex;
 	flex-direction: column;
+	position: relative;
 	box-sizing: border-box;
 	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.35));
 	border-radius: 8px;
@@ -13,6 +14,25 @@
 	text-transform: none;
 	box-shadow: 0 14px 44px rgba(0, 0, 0, 0.45);
 	overflow: hidden;
+}
+
+.use-modal::before {
+	content: '';
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 1px;
+	background: linear-gradient(
+		90deg,
+		transparent 0%,
+		var(--agent-accent, #AFA9EC) 32%,
+		color-mix(in srgb, var(--agent-accent, #AFA9EC) 65%, white) 68%,
+		transparent 100%
+	);
+	opacity: 0.55;
+	z-index: 10;
+	pointer-events: none;
 }
 
 .use-header {

--- a/src/clihub/webview/tools/modal-use/components/use.css
+++ b/src/clihub/webview/tools/modal-use/components/use.css
@@ -95,6 +95,39 @@
 	text-transform: uppercase;
 }
 
+.use-section-row {
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+}
+
+.use-refresh-btn {
+	flex: 0 0 auto;
+	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.24));
+	border-radius: 4px;
+	padding: 4px 8px;
+	background: var(--vscode-toolbar-hoverBackground, rgba(128, 128, 128, 0.1));
+	color: var(--vscode-foreground);
+	font-family: var(--vscode-font-family);
+	font-size: 11px;
+	line-height: 1;
+	cursor: pointer;
+}
+
+.use-refresh-btn:hover:not(:disabled),
+.use-refresh-btn:focus-visible {
+	border-color: color-mix(in srgb, var(--agent-accent, var(--vscode-focusBorder, #3b82f6)) 38%, transparent);
+	background: color-mix(in srgb, var(--agent-accent, var(--vscode-focusBorder, #3b82f6)) 12%, transparent);
+	outline: none;
+}
+
+.use-refresh-btn:disabled {
+	cursor: default;
+	opacity: 0.62;
+}
+
 .use-status-card {
 	min-width: 0;
 	min-height: 48px;
@@ -174,6 +207,118 @@
 	letter-spacing: 0;
 }
 
+.use-usage-card {
+	min-width: 0;
+	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.24));
+	border-radius: 6px;
+	padding: 10px;
+	box-sizing: border-box;
+	background: var(--vscode-input-background, rgba(128, 128, 128, 0.08));
+}
+
+.use-usage-message {
+	min-height: 58px;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 4px;
+}
+
+.use-usage-message strong {
+	color: var(--vscode-foreground);
+	font-size: 12px;
+	line-height: 1.25;
+}
+
+.use-usage-message span {
+	color: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72));
+	font-family: var(--vscode-editor-font-family, ui-monospace, monospace);
+	font-size: 11px;
+	line-height: 1.25;
+}
+
+.use-usage-result {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.use-usage-result[hidden],
+.use-usage-message[hidden] {
+	display: none;
+}
+
+.use-usage-head {
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.use-usage-head strong,
+.use-usage-head span {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 12px;
+	line-height: 1.25;
+}
+
+.use-usage-head span {
+	flex: 0 0 auto;
+	color: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72));
+	font-family: var(--vscode-editor-font-family, ui-monospace, monospace);
+}
+
+.use-usage-bar {
+	height: 8px;
+	border-radius: 999px;
+	overflow: hidden;
+	background: var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.18));
+}
+
+.use-usage-bar span {
+	display: block;
+	width: 0%;
+	height: 100%;
+	border-radius: inherit;
+	background: linear-gradient(90deg, #f472b6, #c084fc);
+	transition: width 180ms ease;
+}
+
+.use-usage-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 8px;
+}
+
+.use-usage-grid div {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.use-usage-grid span {
+	color: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72));
+	font-size: 10px;
+	line-height: 1.2;
+}
+
+.use-usage-grid strong {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--vscode-foreground);
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1.25;
+}
+
 @media (max-width: 520px) {
 	.use-modal {
 		width: calc(100vw - 20px);
@@ -190,5 +335,9 @@
 
 	.use-status-time {
 		align-items: flex-start;
+	}
+
+	.use-usage-grid {
+		grid-template-columns: 1fr;
 	}
 }

--- a/src/clihub/webview/tools/modal-use/components/use.css
+++ b/src/clihub/webview/tools/modal-use/components/use.css
@@ -536,8 +536,4 @@
 	.use-status-time {
 		align-items: flex-start;
 	}
-
-	.use-usage-grid {
-		grid-template-columns: 1fr;
-	}
 }

--- a/src/clihub/webview/tools/modal-use/components/use.css
+++ b/src/clihub/webview/tools/modal-use/components/use.css
@@ -276,7 +276,48 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
+	align-items: flex-start;
 	gap: 4px;
+}
+
+.use-usage-message.is-empty-state {
+	align-items: center;
+	gap: 9px;
+	padding: 4px 18px;
+	text-align: center;
+}
+
+.use-empty-face {
+	--use-empty-dot: color-mix(in srgb, var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72)) 44%, transparent);
+	--use-empty-dot-strong: color-mix(in srgb, var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72)) 72%, transparent);
+	display: none;
+	position: relative;
+	width: 72px;
+	height: 46px;
+	flex: 0 0 auto;
+	opacity: 0.82;
+}
+
+.use-empty-face::before {
+	content: '';
+	position: absolute;
+	inset: 0;
+	background:
+		radial-gradient(circle at 22px 17px, var(--use-empty-dot-strong) 0 2px, transparent 2.2px),
+		radial-gradient(circle at 50px 17px, var(--use-empty-dot-strong) 0 2px, transparent 2.2px),
+		radial-gradient(circle at 28px 32px, var(--use-empty-dot-strong) 0 1.8px, transparent 2px),
+		radial-gradient(circle at 36px 35px, var(--use-empty-dot-strong) 0 1.8px, transparent 2px),
+		radial-gradient(circle at 44px 32px, var(--use-empty-dot-strong) 0 1.8px, transparent 2px),
+		radial-gradient(circle, var(--use-empty-dot) 0 1.2px, transparent 1.4px);
+	background-size: 100% 100%, 100% 100%, 100% 100%, 100% 100%, 100% 100%, 8px 8px;
+}
+
+.use-usage-message.is-empty-state .use-empty-face {
+	display: block;
+}
+
+.use-usage-message.is-refreshing-empty .use-empty-face {
+	animation: use-empty-nudge 520ms ease;
 }
 
 .use-usage-message strong {
@@ -290,6 +331,11 @@
 	font-family: var(--vscode-editor-font-family, ui-monospace, monospace);
 	font-size: 11px;
 	line-height: 1.25;
+}
+
+.use-usage-message.is-empty-state span {
+	max-width: 320px;
+	font-family: var(--vscode-font-family);
 }
 
 .use-usage-result {
@@ -455,6 +501,21 @@
 @keyframes use-loading-sweep {
 	to {
 		transform: translateX(100%);
+	}
+}
+
+@keyframes use-empty-nudge {
+	0%,
+	100% {
+		transform: translateY(0);
+	}
+
+	35% {
+		transform: translateY(-2px);
+	}
+
+	70% {
+		transform: translateY(1px);
 	}
 }
 

--- a/src/clihub/webview/tools/modal-use/components/use.css
+++ b/src/clihub/webview/tools/modal-use/components/use.css
@@ -10,6 +10,7 @@
 	color: var(--vscode-foreground);
 	font-family: var(--vscode-font-family);
 	font-size: 13px;
+	text-transform: none;
 	box-shadow: 0 14px 44px rgba(0, 0, 0, 0.45);
 	overflow: hidden;
 }

--- a/src/clihub/webview/tools/modal-use/components/use.css
+++ b/src/clihub/webview/tools/modal-use/components/use.css
@@ -1,0 +1,198 @@
+.use-modal {
+	width: min(520px, calc(100vw - 32px));
+	max-height: min(520px, calc(100vh - 32px));
+	display: flex;
+	flex-direction: column;
+	box-sizing: border-box;
+	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.35));
+	border-radius: 8px;
+	background: var(--vscode-editor-background);
+	color: var(--vscode-foreground);
+	font-family: var(--vscode-font-family);
+	font-size: 13px;
+	box-shadow: 0 14px 44px rgba(0, 0, 0, 0.45);
+	overflow: hidden;
+}
+
+.use-header {
+	flex: 0 0 auto;
+	padding: 16px 18px 12px;
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+}
+
+.use-title-group {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.use-title {
+	font-size: 15px;
+	font-weight: 650;
+	line-height: 1.25;
+	letter-spacing: 0;
+}
+
+.use-subtitle {
+	color: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72));
+	font-size: 11px;
+	line-height: 1.35;
+}
+
+.use-close-btn {
+	flex: 0 0 auto;
+	border: none;
+	border-radius: 4px;
+	padding: 3px 6px;
+	background: transparent;
+	color: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72));
+	font-family: var(--vscode-editor-font-family, ui-monospace, monospace);
+	font-size: 11px;
+	line-height: 1;
+	cursor: pointer;
+}
+
+.use-close-btn:hover,
+.use-close-btn:focus-visible {
+	background: var(--vscode-toolbar-hoverBackground, rgba(128, 128, 128, 0.14));
+	color: var(--vscode-foreground);
+	outline: none;
+}
+
+.use-divider {
+	height: 1px;
+	background: var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.2));
+}
+
+.use-content {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 14px 14px 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	scrollbar-width: thin;
+}
+
+.use-section {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.use-section-title {
+	padding: 0 4px;
+	color: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.65));
+	font-size: 11px;
+	font-weight: 650;
+	line-height: 1.2;
+	text-transform: uppercase;
+}
+
+.use-status-card {
+	min-width: 0;
+	min-height: 64px;
+	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.24));
+	border-radius: 6px;
+	padding: 12px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	box-sizing: border-box;
+	background: color-mix(in srgb, var(--agent-accent, var(--vscode-focusBorder, #3b82f6)) 8%, transparent);
+}
+
+.use-status-dot {
+	width: 9px;
+	height: 9px;
+	flex: 0 0 auto;
+	border-radius: 999px;
+	background: #64748b;
+	box-shadow: 0 0 0 4px color-mix(in srgb, #64748b 18%, transparent);
+}
+
+.use-status-dot.is-running {
+	background: #10b981;
+	box-shadow: 0 0 0 4px color-mix(in srgb, #10b981 18%, transparent);
+}
+
+.use-status-dot.is-exited {
+	background: #f59e0b;
+	box-shadow: 0 0 0 4px color-mix(in srgb, #f59e0b 18%, transparent);
+}
+
+.use-status-dot.is-error {
+	background: #ef4444;
+	box-shadow: 0 0 0 4px color-mix(in srgb, #ef4444 18%, transparent);
+}
+
+.use-status-copy {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+
+.use-status-label,
+.use-field-label {
+	color: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72));
+	font-size: 11px;
+	line-height: 1.2;
+}
+
+.use-status-value,
+.use-field-value {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--vscode-foreground);
+	font-size: 12px;
+	font-weight: 600;
+	line-height: 1.35;
+}
+
+.use-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 8px;
+}
+
+.use-field {
+	min-width: 0;
+	min-height: 54px;
+	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.2));
+	border-radius: 6px;
+	padding: 10px 11px;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 4px;
+	box-sizing: border-box;
+	background: var(--vscode-input-background, rgba(128, 128, 128, 0.08));
+}
+
+.use-field-wide {
+	grid-column: 1 / -1;
+}
+
+@media (max-width: 520px) {
+	.use-modal {
+		width: calc(100vw - 20px);
+		max-height: calc(100vh - 20px);
+	}
+
+	.use-header {
+		padding: 14px 16px 10px;
+	}
+
+	.use-grid {
+		grid-template-columns: 1fr;
+	}
+}

--- a/src/clihub/webview/tools/modal-use/components/use.css
+++ b/src/clihub/webview/tools/modal-use/components/use.css
@@ -129,6 +129,10 @@
 	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.24));
 	border-radius: 4px;
 	padding: 4px 8px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
 	background: var(--vscode-toolbar-hoverBackground, rgba(128, 128, 128, 0.1));
 	color: var(--vscode-foreground);
 	font-family: var(--vscode-font-family);
@@ -147,6 +151,16 @@
 .use-refresh-btn:disabled {
 	cursor: default;
 	opacity: 0.62;
+}
+
+.use-refresh-btn.is-loading::before {
+	content: '';
+	width: 8px;
+	height: 8px;
+	border: 1px solid color-mix(in srgb, var(--agent-accent, var(--vscode-focusBorder, #3b82f6)) 34%, transparent);
+	border-top-color: var(--agent-accent, var(--vscode-focusBorder, #3b82f6));
+	border-radius: 999px;
+	animation: use-spin 700ms linear infinite;
 }
 
 .use-status-card {
@@ -230,11 +244,30 @@
 
 .use-usage-card {
 	min-width: 0;
+	position: relative;
+	overflow: hidden;
 	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.24));
 	border-radius: 6px;
 	padding: 10px;
 	box-sizing: border-box;
 	background: var(--vscode-input-background, rgba(128, 128, 128, 0.08));
+}
+
+.use-usage-card.is-loading::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(
+		110deg,
+		transparent 0%,
+		transparent 28%,
+		color-mix(in srgb, var(--agent-accent, var(--vscode-focusBorder, #3b82f6)) 18%, transparent) 48%,
+		transparent 68%,
+		transparent 100%
+	);
+	transform: translateX(-100%);
+	animation: use-loading-sweep 1100ms ease-in-out infinite;
+	pointer-events: none;
 }
 
 .use-usage-message {
@@ -338,6 +371,18 @@
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 1.25;
+}
+
+@keyframes use-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+@keyframes use-loading-sweep {
+	to {
+		transform: translateX(100%);
+	}
 }
 
 @media (max-width: 520px) {

--- a/src/clihub/webview/tools/modal-use/components/use.css
+++ b/src/clihub/webview/tools/modal-use/components/use.css
@@ -295,7 +295,7 @@
 	min-width: 0;
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
+	gap: 10px;
 }
 
 .use-usage-result[hidden],
@@ -327,11 +327,75 @@
 	font-family: var(--vscode-editor-font-family, ui-monospace, monospace);
 }
 
+.use-usage-bars {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 9px;
+}
+
+.use-usage-bar-item {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+}
+
+.use-usage-bar-head {
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+}
+
+.use-usage-bar-head strong,
+.use-usage-bar-head span {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 11px;
+	line-height: 1.2;
+}
+
+.use-usage-bar-head strong {
+	color: var(--vscode-foreground);
+	font-weight: 600;
+}
+
+.use-usage-bar-head span,
+.use-usage-bar-detail,
+.use-usage-note {
+	color: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72));
+	font-family: var(--vscode-editor-font-family, ui-monospace, monospace);
+}
+
+.use-usage-bar-detail,
+.use-usage-note {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 10px;
+	line-height: 1.25;
+}
+
+.use-usage-note {
+	border-top: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.16));
+	padding-top: 2px;
+	color: color-mix(in srgb, var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.72)) 82%, transparent);
+}
+
+.use-usage-note[hidden] {
+	display: none;
+}
+
 .use-usage-bar {
-	height: 8px;
+	height: 7px;
 	border-radius: 999px;
 	overflow: hidden;
-	background: var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.18));
+	background: color-mix(in srgb, var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.18)) 82%, transparent);
 }
 
 .use-usage-bar span {
@@ -339,7 +403,13 @@
 	width: 0%;
 	height: 100%;
 	border-radius: inherit;
-	background: linear-gradient(90deg, #f472b6, #c084fc);
+	background: linear-gradient(
+		90deg,
+		color-mix(in srgb, var(--agent-accent, #AFA9EC) 70%, #ffffff 18%),
+		var(--agent-accent, #AFA9EC),
+		color-mix(in srgb, var(--agent-accent, #AFA9EC) 72%, #000000 16%)
+	);
+	box-shadow: 0 0 12px color-mix(in srgb, var(--agent-accent, #AFA9EC) 34%, transparent);
 	transition: width 180ms ease;
 }
 

--- a/src/clihub/webview/tools/modal-use/components/use.css
+++ b/src/clihub/webview/tools/modal-use/components/use.css
@@ -1,6 +1,6 @@
 .use-modal {
 	width: min(430px, calc(100vw - 32px));
-	max-height: min(420px, calc(100vh - 32px));
+	max-height: min(360px, calc(100vh - 32px));
 	display: flex;
 	flex-direction: column;
 	box-sizing: border-box;
@@ -75,7 +75,7 @@
 	padding: 14px 14px 16px;
 	display: flex;
 	flex-direction: column;
-	gap: 16px;
+	gap: 14px;
 	scrollbar-width: thin;
 }
 
@@ -97,10 +97,10 @@
 
 .use-status-card {
 	min-width: 0;
-	min-height: 64px;
+	min-height: 48px;
 	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.24));
 	border-radius: 6px;
-	padding: 12px;
+	padding: 8px 10px;
 	display: flex;
 	align-items: center;
 	gap: 12px;
@@ -134,9 +134,18 @@
 
 .use-status-copy {
 	min-width: 0;
+	flex: 1 1 auto;
 	display: flex;
 	flex-direction: column;
-	gap: 3px;
+	gap: 2px;
+}
+
+.use-status-time {
+	flex: 0 0 auto;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 2px;
 }
 
 .use-status-label,
@@ -158,29 +167,9 @@
 	line-height: 1.35;
 }
 
-.use-metrics {
-	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 8px;
-}
-
-.use-field {
-	min-width: 0;
-	min-height: 68px;
-	border: 1px solid var(--vscode-editorGroup-border, rgba(128, 128, 128, 0.2));
-	border-radius: 6px;
-	padding: 10px 11px;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	gap: 4px;
-	box-sizing: border-box;
-	background: var(--vscode-input-background, rgba(128, 128, 128, 0.08));
-}
-
 .use-field-value-large {
 	font-family: var(--vscode-editor-font-family, ui-monospace, monospace);
-	font-size: 18px;
+	font-size: 13px;
 	font-weight: 700;
 	letter-spacing: 0;
 }
@@ -195,7 +184,11 @@
 		padding: 14px 16px 10px;
 	}
 
-	.use-metrics {
-		grid-template-columns: 1fr;
+	.use-status-card {
+		align-items: flex-start;
+	}
+
+	.use-status-time {
+		align-items: flex-start;
 	}
 }

--- a/src/clihub/webview/tools/modal-use/components/use.html
+++ b/src/clihub/webview/tools/modal-use/components/use.html
@@ -1,8 +1,7 @@
 <div class="use-modal">
 	<div class="use-header">
 		<div class="use-title-group">
-			<div class="use-title">status/use</div>
-			<div class="use-subtitle">active CLI session</div>
+			<div class="use-title">Status / Use</div>
 		</div>
 		<button class="use-close-btn" id="closeUseBtn" type="button" aria-label="Close" title="Close (Esc)">esc</button>
 	</div>
@@ -18,21 +17,15 @@
 					<span class="use-status-label" id="useAgentName">CLI</span>
 					<strong class="use-status-value" id="useStatusValue">No active session</strong>
 				</div>
+				<div class="use-status-time">
+					<span class="use-field-label">Open for</span>
+					<strong class="use-field-value use-field-value-large" id="useOpenFor">--:--:--</strong>
+				</div>
 			</div>
 		</section>
 
 		<section class="use-section">
 			<div class="use-section-title">Use</div>
-			<div class="use-metrics">
-				<div class="use-field">
-					<span class="use-field-label">Open for</span>
-					<strong class="use-field-value use-field-value-large" id="useOpenFor">--:--:--</strong>
-				</div>
-				<div class="use-field">
-					<span class="use-field-label">Tokens left</span>
-					<strong class="use-field-value use-field-value-large" id="useTokensLeft">—</strong>
-				</div>
-			</div>
 		</section>
 	</div>
 </div>

--- a/src/clihub/webview/tools/modal-use/components/use.html
+++ b/src/clihub/webview/tools/modal-use/components/use.html
@@ -1,0 +1,50 @@
+<div class="use-modal">
+	<div class="use-header">
+		<div class="use-title-group">
+			<div class="use-title">status/use</div>
+			<div class="use-subtitle">active CLI session</div>
+		</div>
+		<button class="use-close-btn" id="closeUseBtn" type="button" aria-label="Close" title="Close (Esc)">esc</button>
+	</div>
+
+	<div class="use-divider"></div>
+
+	<div class="use-content">
+		<section class="use-section">
+			<div class="use-section-title">Status</div>
+			<div class="use-status-card">
+				<span class="use-status-dot" id="useStatusDot" aria-hidden="true"></span>
+				<div class="use-status-copy">
+					<span class="use-status-label" id="useAgentName">CLI</span>
+					<strong class="use-status-value" id="useStatusValue">No active session</strong>
+				</div>
+			</div>
+		</section>
+
+		<section class="use-section">
+			<div class="use-section-title">Use</div>
+			<div class="use-grid">
+				<div class="use-field">
+					<span class="use-field-label">Session</span>
+					<strong class="use-field-value" id="useSessionId">none</strong>
+				</div>
+				<div class="use-field">
+					<span class="use-field-label">Model</span>
+					<strong class="use-field-value" id="useModelName">unknown</strong>
+				</div>
+				<div class="use-field use-field-wide">
+					<span class="use-field-label">Workspace</span>
+					<strong class="use-field-value" id="useWorkspace">none</strong>
+				</div>
+				<div class="use-field use-field-wide">
+					<span class="use-field-label">Command</span>
+					<strong class="use-field-value" id="useCommand">none</strong>
+				</div>
+				<div class="use-field">
+					<span class="use-field-label">Filter</span>
+					<strong class="use-field-value" id="useFilterState">off</strong>
+				</div>
+			</div>
+		</section>
+	</div>
+</div>

--- a/src/clihub/webview/tools/modal-use/components/use.html
+++ b/src/clihub/webview/tools/modal-use/components/use.html
@@ -25,7 +25,42 @@
 		</section>
 
 		<section class="use-section">
-			<div class="use-section-title">Use</div>
+			<div class="use-section-row">
+				<div class="use-section-title">Use</div>
+				<button class="use-refresh-btn" id="useRefreshBtn" type="button">
+					<span id="useRefreshLabel">Refresh</span>
+				</button>
+			</div>
+			<div class="use-usage-card">
+				<div class="use-usage-message" id="useUsageMessage">
+					<strong id="useUsageMessageTitle">No usage data</strong>
+					<span id="useUsageMessageDetail">-</span>
+				</div>
+
+				<div class="use-usage-result" id="useUsageResult" hidden>
+					<div class="use-usage-head">
+						<strong id="useUsagePlan">kiro</strong>
+						<span id="useUsagePercent">0.0%</span>
+					</div>
+					<div class="use-usage-bar" aria-hidden="true">
+						<span id="useUsageBar"></span>
+					</div>
+					<div class="use-usage-grid">
+						<div>
+							<span>credits</span>
+							<strong id="useUsageCredits">unknown</strong>
+						</div>
+						<div>
+							<span>resets</span>
+							<strong id="useUsageReset">unknown</strong>
+						</div>
+						<div>
+							<span>overages</span>
+							<strong id="useUsageOverages">unknown</strong>
+						</div>
+					</div>
+				</div>
+			</div>
 		</section>
 	</div>
 </div>

--- a/src/clihub/webview/tools/modal-use/components/use.html
+++ b/src/clihub/webview/tools/modal-use/components/use.html
@@ -38,26 +38,12 @@
 
 				<div class="use-usage-result" id="useUsageResult" hidden>
 					<div class="use-usage-head">
-						<strong id="useUsagePlan">kiro</strong>
-						<span id="useUsagePercent">0.0%</span>
+						<strong id="useUsageTitle">Usage</strong>
+						<span id="useUsageSummary">0.0%</span>
 					</div>
-					<div class="use-usage-bar" aria-hidden="true">
-						<span id="useUsageBar"></span>
-					</div>
-					<div class="use-usage-grid">
-						<div>
-							<span>credits</span>
-							<strong id="useUsageCredits">unknown</strong>
-						</div>
-						<div>
-							<span>resets</span>
-							<strong id="useUsageReset">unknown</strong>
-						</div>
-						<div>
-							<span>overages</span>
-							<strong id="useUsageOverages">unknown</strong>
-						</div>
-					</div>
+					<div class="use-usage-bars" id="useUsageBars"></div>
+					<div class="use-usage-note" id="useUsageNote" hidden></div>
+					<div class="use-usage-grid" id="useUsageMeta"></div>
 				</div>
 			</div>
 		</section>

--- a/src/clihub/webview/tools/modal-use/components/use.html
+++ b/src/clihub/webview/tools/modal-use/components/use.html
@@ -23,26 +23,14 @@
 
 		<section class="use-section">
 			<div class="use-section-title">Use</div>
-			<div class="use-grid">
+			<div class="use-metrics">
 				<div class="use-field">
-					<span class="use-field-label">Session</span>
-					<strong class="use-field-value" id="useSessionId">none</strong>
-				</div>
-				<div class="use-field">
-					<span class="use-field-label">Model</span>
-					<strong class="use-field-value" id="useModelName">unknown</strong>
-				</div>
-				<div class="use-field use-field-wide">
-					<span class="use-field-label">Workspace</span>
-					<strong class="use-field-value" id="useWorkspace">none</strong>
-				</div>
-				<div class="use-field use-field-wide">
-					<span class="use-field-label">Command</span>
-					<strong class="use-field-value" id="useCommand">none</strong>
+					<span class="use-field-label">Open for</span>
+					<strong class="use-field-value use-field-value-large" id="useOpenFor">--:--:--</strong>
 				</div>
 				<div class="use-field">
-					<span class="use-field-label">Filter</span>
-					<strong class="use-field-value" id="useFilterState">off</strong>
+					<span class="use-field-label">Tokens left</span>
+					<strong class="use-field-value use-field-value-large" id="useTokensLeft">—</strong>
 				</div>
 			</div>
 		</section>

--- a/src/clihub/webview/tools/modal-use/components/use.html
+++ b/src/clihub/webview/tools/modal-use/components/use.html
@@ -32,6 +32,7 @@
 			</div>
 			<div class="use-usage-card">
 				<div class="use-usage-message" id="useUsageMessage">
+					<div class="use-empty-face" aria-hidden="true"></div>
 					<strong id="useUsageMessageTitle">No usage data</strong>
 					<span id="useUsageMessageDetail">-</span>
 				</div>

--- a/src/clihub/webview/tools/modal-use/components/use.html
+++ b/src/clihub/webview/tools/modal-use/components/use.html
@@ -1,7 +1,7 @@
 <div class="use-modal">
 	<div class="use-header">
 		<div class="use-title-group">
-			<div class="use-title">Status / Use</div>
+			<div class="use-title" id="useModalTitle">CLI</div>
 		</div>
 		<button class="use-close-btn" id="closeUseBtn" type="button" aria-label="Close" title="Close (Esc)">esc</button>
 	</div>
@@ -14,7 +14,6 @@
 			<div class="use-status-card">
 				<span class="use-status-dot" id="useStatusDot" aria-hidden="true"></span>
 				<div class="use-status-copy">
-					<span class="use-status-label" id="useAgentName">CLI</span>
 					<strong class="use-status-value" id="useStatusValue">No active session</strong>
 				</div>
 				<div class="use-status-time">

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -1,0 +1,90 @@
+import useStyles from './components/use.css';
+import useHtml from './components/use.html';
+import type { ToolContext } from '../tools';
+
+const stylesId = 'cli-use-panel-styles';
+const refreshIntervalMs = 700;
+
+const ensureStyles = () => {
+	if (document.getElementById(stylesId)) {
+		return;
+	}
+
+	const style = document.createElement('style');
+	style.id = stylesId;
+	style.textContent = useStyles;
+	document.head.append(style);
+};
+
+const getText = (id: string, fallback: string) => {
+	const value = document.getElementById(id)?.textContent?.trim();
+	return value || fallback;
+};
+
+const setText = (host: HTMLElement, selector: string, value: string) => {
+	const element = host.querySelector<HTMLElement>(selector);
+	if (!element) {
+		return;
+	}
+
+	element.textContent = value;
+	element.title = value;
+};
+
+const getStatusParts = () => {
+	const statusLine = getText('cli-terminal-status', 'No active session');
+	const separator = ' - ';
+	if (!statusLine.includes(separator)) {
+		return { status: statusLine, workspace: 'none' };
+	}
+
+	const [status, ...workspaceParts] = statusLine.split(separator);
+	return {
+		status: status || 'unknown',
+		workspace: workspaceParts.join(separator) || 'none',
+	};
+};
+
+const setStatusDot = (host: HTMLElement, status: string) => {
+	const dot = host.querySelector<HTMLElement>('#useStatusDot');
+	if (!dot) {
+		return;
+	}
+
+	dot.classList.toggle('is-running', status === 'running');
+	dot.classList.toggle('is-exited', status.startsWith('exited'));
+	dot.classList.toggle('is-error', status === 'error');
+};
+
+const renderUseState = (host: HTMLElement, context: ToolContext) => {
+	const agent = getText('cli-terminal-label', 'CLI');
+	const command = getText('cli-terminal-badge', 'none');
+	const { status, workspace } = getStatusParts();
+	const sessionId = context.getActiveSessionId?.() ?? 'none';
+	const modelName = context.getActiveModelName?.() ?? 'unknown';
+	const filterEnabled = document.querySelector<HTMLInputElement>('#cli-prompt-filter-toggle')?.checked === true;
+
+	setText(host, '#useAgentName', agent);
+	setText(host, '#useStatusValue', status);
+	setText(host, '#useSessionId', sessionId === 'none' ? sessionId : sessionId.slice(0, 8));
+	setText(host, '#useModelName', modelName);
+	setText(host, '#useWorkspace', workspace);
+	setText(host, '#useCommand', command);
+	setText(host, '#useFilterState', filterEnabled ? 'on' : 'off');
+	setStatusDot(host, status);
+};
+
+export const mountUsePanel = (host: HTMLElement, context: ToolContext) => {
+	ensureStyles();
+
+	const template = document.createElement('template');
+	template.innerHTML = (useHtml as unknown as string).trim();
+	host.replaceChildren(template.content.cloneNode(true));
+
+	const closeBtn = host.querySelector<HTMLButtonElement>('#closeUseBtn');
+	closeBtn?.addEventListener('click', () => context.close());
+
+	renderUseState(host, context);
+	const interval = window.setInterval(() => renderUseState(host, context), refreshIntervalMs);
+	return () => window.clearInterval(interval);
+};

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -1,6 +1,6 @@
 import useStyles from './components/use.css';
 import useHtml from './components/use.html';
-import type { ToolContext } from '../tools';
+import type { CliUsageSnapshot, ToolContext } from '../tools';
 
 const stylesId = 'cli-use-panel-styles';
 const refreshIntervalMs = 1000;
@@ -31,6 +31,17 @@ const setText = (host: HTMLElement, selector: string, value: string) => {
 	element.title = value;
 };
 
+const setHidden = (host: HTMLElement, selector: string, hidden: boolean) => {
+	const element = host.querySelector<HTMLElement>(selector);
+	if (!element) {
+		return;
+	}
+
+	element.hidden = hidden;
+};
+
+const stripAnsi = (value: string) => value.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
+
 const getStatusParts = () => {
 	const statusLine = getText('cli-terminal-status', 'No active session');
 	const separator = ' - ';
@@ -43,6 +54,69 @@ const getStatusParts = () => {
 		status: status || 'unknown',
 		workspace: workspaceParts.join(separator) || 'none',
 	};
+};
+
+const getActiveAgentLabel = () => getText('cli-terminal-label', 'CLI');
+
+const getUsageCommandLabel = (agentLabel: string) => (
+	agentLabel.toLowerCase().includes('kiro') ? '/usage' : 'not configured'
+);
+
+const parseKiroUsage = (raw: string) => {
+	const text = stripAnsi(raw);
+	const plan = text.match(/resets on\s+[0-9-]+\s*\|\s*([^\r\n]+)/i)?.[1]?.trim() ?? 'kiro';
+	const reset = text.match(/resets on\s+([0-9-]+)/i)?.[1]?.trim() ?? 'unknown';
+	const credits = text.match(/credits\s*\(([^)]+)\)/i)?.[1]?.trim() ?? 'unknown';
+	const percentValue = Number(text.match(/(\d+(?:\.\d+)?)\s*%/)?.[1] ?? NaN);
+	const percent = Number.isFinite(percentValue) ? Math.max(0, Math.min(100, percentValue)) : 0;
+	const overages = text.match(/overages:\s*([^\r\n]+)/i)?.[1]?.trim() ?? 'unknown';
+
+	return { plan, reset, credits, percent, overages };
+};
+
+const renderUsageMessage = (host: HTMLElement, title: string, detail: string) => {
+	setHidden(host, '#useUsageResult', true);
+	setHidden(host, '#useUsageMessage', false);
+	setText(host, '#useUsageMessageTitle', title);
+	setText(host, '#useUsageMessageDetail', detail);
+};
+
+const renderUsageSnapshot = (host: HTMLElement, snapshot: CliUsageSnapshot | undefined) => {
+	if (!snapshot) {
+		const agent = getActiveAgentLabel();
+		renderUsageMessage(host, 'No usage data', getUsageCommandLabel(agent));
+		return;
+	}
+
+	if (!snapshot.agentLabel.toLowerCase().includes('kiro')) {
+		renderUsageMessage(host, 'Not configured', snapshot.agentLabel);
+		return;
+	}
+
+	const parsed = parseKiroUsage(snapshot.raw);
+	setHidden(host, '#useUsageMessage', true);
+	setHidden(host, '#useUsageResult', false);
+	setText(host, '#useUsagePlan', parsed.plan);
+	setText(host, '#useUsageCredits', parsed.credits);
+	setText(host, '#useUsagePercent', `${parsed.percent.toFixed(1)}%`);
+	setText(host, '#useUsageReset', parsed.reset);
+	setText(host, '#useUsageOverages', parsed.overages);
+
+	const bar = host.querySelector<HTMLElement>('#useUsageBar');
+	if (bar) {
+		bar.style.width = `${parsed.percent}%`;
+	}
+};
+
+const setRefreshState = (host: HTMLElement, isLoading: boolean) => {
+	const button = host.querySelector<HTMLButtonElement>('#useRefreshBtn');
+	if (!button) {
+		return;
+	}
+
+	button.disabled = isLoading;
+	button.classList.toggle('is-loading', isLoading);
+	setText(host, '#useRefreshLabel', isLoading ? 'Loading' : 'Refresh');
 };
 
 const setStatusDot = (host: HTMLElement, status: string) => {
@@ -91,7 +165,25 @@ export const mountUsePanel = (host: HTMLElement, context: ToolContext) => {
 	const closeBtn = host.querySelector<HTMLButtonElement>('#closeUseBtn');
 	closeBtn?.addEventListener('click', () => context.close());
 
+	const refreshBtn = host.querySelector<HTMLButtonElement>('#useRefreshBtn');
+	refreshBtn?.addEventListener('click', () => {
+		if (!context.requestUsage) {
+			renderUsageMessage(host, 'Not configured', getActiveAgentLabel());
+			return;
+		}
+
+		setRefreshState(host, true);
+		void context.requestUsage()
+			.then((snapshot) => renderUsageSnapshot(host, snapshot))
+			.catch((error) => {
+				const message = error instanceof Error ? error.message : 'Usage refresh failed.';
+				renderUsageMessage(host, 'Refresh failed', message);
+			})
+			.finally(() => setRefreshState(host, false));
+	});
+
 	renderUseState(host, context);
+	renderUsageSnapshot(host, context.getUsageSnapshot?.());
 	const interval = window.setInterval(() => renderUseState(host, context), refreshIntervalMs);
 	return () => window.clearInterval(interval);
 };

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -57,7 +57,7 @@ type UsageMetric = {
 
 type ParsedUsage = {
 	title: string;
-	summary: string;
+	summary?: string;
 	bars: UsageBar[];
 	metrics: UsageMetric[];
 	note?: string;
@@ -172,6 +172,12 @@ const getCleanLine = (line: string) => line
 	.replace(/\s+/g, ' ')
 	.trim();
 
+const stripCodexVisualBar = (line: string) => line
+	.replace(/\[[\s█▓▒░#=+\-.]{3,}\]/g, ' ')
+	.replace(/[█▓▒░]{3,}/g, ' ')
+	.replace(/\s+/g, ' ')
+	.trim();
+
 const titleCase = (value: string) => value
 	.replace(/[_-]+/g, ' ')
 	.replace(/\b\w/g, (char) => char.toUpperCase())
@@ -184,7 +190,8 @@ const getCodexPercentBars = (text: string): UsageBar[] => {
 	const bars: UsageBar[] = [];
 
 	for (const line of lines) {
-		const percentMatch = line.match(/(\d+(?:\.\d+)?)\s*%\s*(used|remaining|left)?/i);
+		const cleanLine = stripCodexVisualBar(line);
+		const percentMatch = cleanLine.match(/(\d+(?:\.\d+)?)\s*%\s*(used|remaining|left)?/i);
 		if (!percentMatch) {
 			continue;
 		}
@@ -192,7 +199,7 @@ const getCodexPercentBars = (text: string): UsageBar[] => {
 		const rawPercent = parsePercent(percentMatch[1]);
 		const mode = percentMatch[2]?.toLowerCase();
 		const percent = mode === 'remaining' || mode === 'left' ? 100 - rawPercent : rawPercent;
-		const labelSource = line
+		const labelSource = cleanLine
 			.replace(percentMatch[0], '')
 			.replace(/\b(used|remaining|left)\b/gi, '')
 			.replace(/[:•·-]+$/g, '')
@@ -255,7 +262,6 @@ const parseCodexUsage = (raw: string): ParsedUsage => {
 
 	return {
 		title: 'Codex status',
-		summary: bars[0] ? `${formatPercent(bars[0].percent)} used` : '/status',
 		bars: bars.length > 0 ? bars : [
 			{ label: 'Status', percent: 0, detail: 'No usage percentage found in /status output' }
 		],
@@ -359,7 +365,10 @@ const renderUsageSnapshot = (host: HTMLElement, snapshot: CliUsageSnapshot | und
 	const result = host.querySelector<HTMLElement>('#useUsageResult');
 	setHidden(host, '#useUsageResult', false);
 	setText(host, '#useUsageTitle', parsed.title);
-	setText(host, '#useUsageSummary', parsed.summary);
+	setHidden(host, '#useUsageSummary', !parsed.summary);
+	if (parsed.summary) {
+		setText(host, '#useUsageSummary', parsed.summary);
+	}
 
 	const bars = host.querySelector<HTMLElement>('#useUsageBars');
 	if (bars) {

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -42,7 +42,7 @@ const setHidden = (host: HTMLElement, selector: string, hidden: boolean) => {
 
 const stripAnsi = (value: string) => value.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
 
-type UsageAgentKind = 'claude' | 'codex' | 'kiro';
+type UsageAgentKind = 'antigravity' | 'claude' | 'codex' | 'kiro';
 
 type UsageBar = {
 	label: string;
@@ -82,6 +82,9 @@ const getActiveAgentLabel = () => getText('cli-terminal-label', 'CLI');
 
 const getUsageAgentKind = (agentLabel: string): UsageAgentKind | undefined => {
 	const lower = agentLabel.toLowerCase();
+	if (lower.includes('antigravity')) {
+		return 'antigravity';
+	}
 	if (lower.includes('claude')) {
 		return 'claude';
 	}
@@ -173,9 +176,9 @@ const getCleanLine = (line: string) => line
 	.replace(/\s+/g, ' ')
 	.trim();
 
-const stripCodexVisualBar = (line: string) => line
-	.replace(/\[[\s█▓▒░#=+\-.]{3,}\]/g, ' ')
-	.replace(/[█▓▒░]{3,}/g, ' ')
+const stripUsageVisualBar = (line: string) => line
+	.replace(/\[[\s█▓▒░#=+\-.▏▎▍▌▋▊▉■□▁▂▃▄▅▆▇━─]{3,}\]/g, ' ')
+	.replace(/[█▓▒░▏▎▍▌▋▊▉■□▁▂▃▄▅▆▇]{3,}/g, ' ')
 	.replace(/\s+/g, ' ')
 	.trim();
 
@@ -186,9 +189,83 @@ const titleCase = (value: string) => value
 
 const parseCompactNumber = (value: string) => Number(value.replace(/[,_\s]/g, ''));
 
+const getAntigravityGroupLabel = (value: string) => titleCase(value)
+	.replace(/\bAnd\b/g, 'and')
+	.replace(/\bGpt\b/g, 'GPT');
+
+const getAntigravityMetricLabel = (label: string) => {
+	const normalized = label
+		.toLowerCase()
+		.replace(/\s+models\b/g, '')
+		.replace(/\s+and\s+/g, '/')
+		.trim();
+	return `${normalized || label.toLowerCase()} refresh`;
+};
+
+const parseAntigravityUsage = (raw: string): ParsedUsage => {
+	const text = stripAnsi(raw);
+	const lines = text.split(/\r?\n/).map(getCleanLine).filter(Boolean);
+	const bars: UsageBar[] = [];
+	let groupLabel = 'Weekly limit';
+
+	for (let index = 0; index < lines.length; index += 1) {
+		const cleanLine = stripUsageVisualBar(lines[index]);
+		if (!cleanLine) {
+			continue;
+		}
+
+		if (/models?$/i.test(cleanLine) && !/models within/i.test(cleanLine)) {
+			groupLabel = getAntigravityGroupLabel(cleanLine);
+			continue;
+		}
+
+		const remainingMatch = cleanLine.match(/(\d+(?:\.\d+)?)\s*%\s*(remaining|left)/i);
+		if (!remainingMatch) {
+			continue;
+		}
+
+		const previousLinePercent = stripUsageVisualBar(lines[index - 1] ?? '')
+			.match(/(\d+(?:\.\d+)?)\s*%/)?.[1];
+		const remaining = parsePercent(previousLinePercent ?? remainingMatch[1]);
+		const refresh = cleanLine.match(/refreshes?\s+in\s+([^·\r\n]+)/i)?.[1]?.trim();
+		const detail = [
+			`${formatPercent(remaining)} remaining`,
+			refresh ? `refreshes in ${refresh}` : undefined
+		].filter((part): part is string => !!part).join(' - ');
+
+		bars.push({
+			label: groupLabel,
+			percent: 100 - remaining,
+			detail,
+			reset: refresh
+		});
+	}
+
+	const metrics = bars
+		.filter((bar) => !!bar.reset)
+		.map((bar): UsageMetric => ({
+			label: getAntigravityMetricLabel(bar.label),
+			value: bar.reset ?? 'unknown'
+		}))
+		.slice(0, 3);
+
+	return {
+		title: 'Antigravity usage',
+		summary: bars.length === 1 ? '1 weekly group' : bars.length > 1 ? `${bars.length} weekly groups` : '/usage',
+		bars: bars.length > 0 ? bars : [
+			{ label: 'Weekly limit', percent: 0, detail: 'No usage percentage found in /usage output' }
+		],
+		metrics: metrics.length > 0 ? metrics : [
+			{ label: 'command', value: '/usage' },
+			{ label: 'usage', value: bars.length > 0 ? 'detected' : 'not reported' },
+			{ label: 'source', value: 'Antigravity CLI' }
+		]
+	};
+};
+
 const getCodexResetDetail = (lines: string[], startIndex: number) => {
 	for (const line of lines.slice(startIndex + 1, startIndex + 3)) {
-		if (/\d+(?:\.\d+)?\s*%\s*(?:used|remaining|left)?/i.test(stripCodexVisualBar(line))) {
+		if (/\d+(?:\.\d+)?\s*%\s*(?:used|remaining|left)?/i.test(stripUsageVisualBar(line))) {
 			return undefined;
 		}
 
@@ -206,7 +283,7 @@ const getCodexPercentBars = (text: string): UsageBar[] => {
 
 	for (let index = 0; index < lines.length; index += 1) {
 		const line = lines[index];
-		const cleanLine = stripCodexVisualBar(line);
+		const cleanLine = stripUsageVisualBar(line);
 		const percentMatch = cleanLine.match(/(\d+(?:\.\d+)?)\s*%\s*(used|remaining|left)?/i);
 		if (!percentMatch) {
 			continue;
@@ -308,6 +385,9 @@ const parseCodexUsage = (raw: string): ParsedUsage => {
 
 const parseUsage = (snapshot: CliUsageSnapshot): ParsedUsage | undefined => {
 	const kind = getUsageAgentKind(snapshot.agentLabel);
+	if (kind === 'antigravity') {
+		return parseAntigravityUsage(snapshot.raw);
+	}
 	if (kind === 'claude') {
 		return parseClaudeUsage(snapshot.raw);
 	}

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -400,11 +400,37 @@ const parseUsage = (snapshot: CliUsageSnapshot): ParsedUsage | undefined => {
 	return undefined;
 };
 
-const renderUsageMessage = (host: HTMLElement, title: string, detail: string) => {
+const triggerEmptyRefreshAnimation = (host: HTMLElement) => {
+	const message = host.querySelector<HTMLElement>('#useUsageMessage');
+	if (!message) {
+		return;
+	}
+
+	message.classList.remove('is-refreshing-empty');
+	void message.offsetWidth;
+	message.classList.add('is-refreshing-empty');
+	window.setTimeout(() => message.classList.remove('is-refreshing-empty'), 560);
+};
+
+const renderUsageMessage = (host: HTMLElement, title: string, detail: string, options?: { empty?: boolean; animate?: boolean }) => {
 	setHidden(host, '#useUsageResult', true);
 	setHidden(host, '#useUsageMessage', false);
+	const message = host.querySelector<HTMLElement>('#useUsageMessage');
+	message?.classList.toggle('is-empty-state', options?.empty === true);
 	setText(host, '#useUsageMessageTitle', title);
 	setText(host, '#useUsageMessageDetail', detail);
+	if (options?.animate) {
+		triggerEmptyRefreshAnimation(host);
+	}
+};
+
+const renderUnsupportedUsage = (host: HTMLElement, animate = false) => {
+	renderUsageMessage(
+		host,
+		'Not available yet',
+		'This CLI does not expose usage data here yet.',
+		{ empty: true, animate }
+	);
 };
 
 const createUsageBar = (bar: UsageBar) => {
@@ -461,13 +487,17 @@ const createUsageMetric = (metric: UsageMetric) => {
 const renderUsageSnapshot = (host: HTMLElement, snapshot: CliUsageSnapshot | undefined) => {
 	if (!snapshot) {
 		const agent = getActiveAgentLabel();
+		if (getUsageCommandLabel(agent) === 'not configured') {
+			renderUnsupportedUsage(host);
+			return;
+		}
 		renderUsageMessage(host, 'No usage data', getUsageCommandLabel(agent));
 		return;
 	}
 
 	const parsed = parseUsage(snapshot);
 	if (!parsed) {
-		renderUsageMessage(host, 'Not configured', snapshot.agentLabel);
+		renderUnsupportedUsage(host);
 		return;
 	}
 
@@ -601,13 +631,13 @@ export const mountUsePanel = (host: HTMLElement, context: ToolContext) => {
 		}
 
 		if (!context.requestUsage) {
-			renderUsageMessage(host, 'Not configured', getActiveAgentLabel());
+			renderUnsupportedUsage(host, true);
 			return;
 		}
 
 		const commandLabel = getUsageCommandLabel(getActiveAgentLabel());
 		if (commandLabel === 'not configured') {
-			renderUsageMessage(host, 'Not configured', getActiveAgentLabel());
+			renderUnsupportedUsage(host, true);
 			return;
 		}
 

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -48,6 +48,7 @@ type UsageBar = {
 	label: string;
 	percent: number;
 	detail?: string;
+	reset?: string;
 };
 
 type UsageMetric = {
@@ -185,11 +186,26 @@ const titleCase = (value: string) => value
 
 const parseCompactNumber = (value: string) => Number(value.replace(/[,_\s]/g, ''));
 
+const getCodexResetDetail = (lines: string[], startIndex: number) => {
+	for (const line of lines.slice(startIndex + 1, startIndex + 3)) {
+		if (/\d+(?:\.\d+)?\s*%\s*(?:used|remaining|left)?/i.test(stripCodexVisualBar(line))) {
+			return undefined;
+		}
+
+		const reset = line.match(/\(?\s*resets\s+([^)]+?)\s*\)?$/i)?.[1]?.trim();
+		if (reset) {
+			return reset;
+		}
+	}
+	return undefined;
+};
+
 const getCodexPercentBars = (text: string): UsageBar[] => {
 	const lines = text.split(/\r?\n/).map(getCleanLine).filter(Boolean);
 	const bars: UsageBar[] = [];
 
-	for (const line of lines) {
+	for (let index = 0; index < lines.length; index += 1) {
+		const line = lines[index];
 		const cleanLine = stripCodexVisualBar(line);
 		const percentMatch = cleanLine.match(/(\d+(?:\.\d+)?)\s*%\s*(used|remaining|left)?/i);
 		if (!percentMatch) {
@@ -205,14 +221,21 @@ const getCodexPercentBars = (text: string): UsageBar[] => {
 			.replace(/[:•·-]+$/g, '')
 			.trim();
 		const label = labelSource ? titleCase(labelSource) : 'Status';
-		const detail = mode === 'remaining' || mode === 'left'
-			? `${formatPercent(rawPercent)} ${mode}`
-			: undefined;
+		const reset = getCodexResetDetail(lines, index);
+		const details = [
+			mode === 'remaining' || mode === 'left' ? `${formatPercent(rawPercent)} ${mode}` : undefined,
+			reset ? `resets ${reset}` : undefined
+		].filter((detail): detail is string => !!detail);
 
-		bars.push({ label, percent, detail });
+		bars.push({ label, percent, detail: details.join(' - ') || undefined, reset });
 	}
 
 	return bars.slice(0, 2);
+};
+
+const getCodexResetMetricLabel = (label: string) => {
+	const cleanLabel = label.toLowerCase().replace(/\s+limit\b/, '').trim();
+	return `${cleanLabel || label.toLowerCase()} reset`;
 };
 
 const getCodexTokenBar = (text: string): UsageBar | undefined => {
@@ -254,7 +277,14 @@ const parseCodexUsage = (raw: string): ParsedUsage => {
 		bars.push(tokenBar);
 	}
 
+	const resetMetrics = bars
+		.filter((bar) => !!bar.reset)
+		.map((bar): UsageMetric => ({
+			label: getCodexResetMetricLabel(bar.label),
+			value: bar.reset ?? 'unknown'
+		}));
 	const metrics = [
+		...resetMetrics,
 		getCodexMetric(text, 'model', /\bmodel\s*[:=]\s*([^\r\n]+)/i),
 		getCodexMetric(text, 'approval', /\bapproval(?:s)?\s*[:=]\s*([^\r\n]+)/i),
 		getCodexMetric(text, 'sandbox', /\bsandbox\s*[:=]\s*([^\r\n]+)/i)

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -110,13 +110,17 @@ const renderUsageSnapshot = (host: HTMLElement, snapshot: CliUsageSnapshot | und
 
 const setRefreshState = (host: HTMLElement, isLoading: boolean) => {
 	const button = host.querySelector<HTMLButtonElement>('#useRefreshBtn');
-	if (!button) {
-		return;
+	const usageCard = host.querySelector<HTMLElement>('.use-usage-card');
+	if (button) {
+		button.disabled = isLoading;
+		button.classList.toggle('is-loading', isLoading);
+		setText(host, '#useRefreshLabel', isLoading ? 'Loading' : 'Refresh');
 	}
 
-	button.disabled = isLoading;
-	button.classList.toggle('is-loading', isLoading);
-	setText(host, '#useRefreshLabel', isLoading ? 'Loading' : 'Refresh');
+	if (usageCard) {
+		usageCard.classList.toggle('is-loading', isLoading);
+		usageCard.setAttribute('aria-busy', String(isLoading));
+	}
 };
 
 const setStatusDot = (host: HTMLElement, status: string) => {
@@ -159,6 +163,8 @@ export const mountUsePanel = (host: HTMLElement, context: ToolContext) => {
 	ensureStyles();
 	let shouldDismissCliUsageView = false;
 	let didDismissCliUsageView = false;
+	let isRefreshingUsage = false;
+	let isDisposed = false;
 
 	const template = document.createElement('template');
 	template.innerHTML = (useHtml as unknown as string).trim();
@@ -179,29 +185,59 @@ export const mountUsePanel = (host: HTMLElement, context: ToolContext) => {
 		context.close();
 	});
 
-	const refreshBtn = host.querySelector<HTMLButtonElement>('#useRefreshBtn');
-	refreshBtn?.addEventListener('click', () => {
+	const refreshUsage = () => {
+		if (isDisposed || isRefreshingUsage) {
+			return;
+		}
+
 		if (!context.requestUsage) {
 			renderUsageMessage(host, 'Not configured', getActiveAgentLabel());
 			return;
 		}
 
+		const commandLabel = getUsageCommandLabel(getActiveAgentLabel());
+		if (commandLabel === 'not configured') {
+			renderUsageMessage(host, 'Not configured', getActiveAgentLabel());
+			return;
+		}
+
+		isRefreshingUsage = true;
 		shouldDismissCliUsageView = true;
+		renderUsageMessage(host, 'Loading usage', commandLabel);
 		setRefreshState(host, true);
 		void context.requestUsage()
-			.then((snapshot) => renderUsageSnapshot(host, snapshot))
+			.then((snapshot) => {
+				if (!isDisposed) {
+					renderUsageSnapshot(host, snapshot);
+				}
+			})
 			.catch((error) => {
 				shouldDismissCliUsageView = false;
+				if (isDisposed) {
+					return;
+				}
 				const message = error instanceof Error ? error.message : 'Usage refresh failed.';
 				renderUsageMessage(host, 'Refresh failed', message);
 			})
-			.finally(() => setRefreshState(host, false));
-	});
+			.finally(() => {
+				isRefreshingUsage = false;
+				if (!isDisposed) {
+					setRefreshState(host, false);
+				}
+			});
+	};
+
+	const refreshBtn = host.querySelector<HTMLButtonElement>('#useRefreshBtn');
+	refreshBtn?.addEventListener('click', refreshUsage);
 
 	renderUseState(host, context);
 	renderUsageSnapshot(host, context.getUsageSnapshot?.());
+	if (getUsageCommandLabel(getActiveAgentLabel()) !== 'not configured') {
+		window.setTimeout(refreshUsage, 0);
+	}
 	const interval = window.setInterval(() => renderUseState(host, context), refreshIntervalMs);
 	return () => {
+		isDisposed = true;
 		window.clearInterval(interval);
 		dismissCliUsageView();
 	};

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -42,6 +42,27 @@ const setHidden = (host: HTMLElement, selector: string, hidden: boolean) => {
 
 const stripAnsi = (value: string) => value.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
 
+type UsageAgentKind = 'claude' | 'kiro';
+
+type UsageBar = {
+	label: string;
+	percent: number;
+	detail?: string;
+};
+
+type UsageMetric = {
+	label: string;
+	value: string;
+};
+
+type ParsedUsage = {
+	title: string;
+	summary: string;
+	bars: UsageBar[];
+	metrics: UsageMetric[];
+	note?: string;
+};
+
 const getStatusParts = () => {
 	const statusLine = getText('cli-terminal-status', 'No active session');
 	const separator = ' - ';
@@ -58,20 +79,96 @@ const getStatusParts = () => {
 
 const getActiveAgentLabel = () => getText('cli-terminal-label', 'CLI');
 
+const getUsageAgentKind = (agentLabel: string): UsageAgentKind | undefined => {
+	const lower = agentLabel.toLowerCase();
+	if (lower.includes('claude')) {
+		return 'claude';
+	}
+	if (lower.includes('kiro')) {
+		return 'kiro';
+	}
+	return undefined;
+};
+
 const getUsageCommandLabel = (agentLabel: string) => (
-	agentLabel.toLowerCase().includes('kiro') ? '/usage' : 'not configured'
+	getUsageAgentKind(agentLabel) ? '/usage' : 'not configured'
 );
 
-const parseKiroUsage = (raw: string) => {
+const clampPercent = (value: number) => (
+	Number.isFinite(value) ? Math.max(0, Math.min(100, value)) : 0
+);
+
+const parsePercent = (value: string | undefined) => clampPercent(Number(value ?? NaN));
+
+const formatPercent = (value: number) => `${clampPercent(value).toFixed(1)}%`;
+
+const getSection = (text: string, start: RegExp, end: RegExp) => {
+	const startMatch = start.exec(text);
+	if (!startMatch) {
+		return '';
+	}
+
+	const rest = text.slice(startMatch.index + startMatch[0].length);
+	const endMatch = end.exec(rest);
+	return (endMatch ? rest.slice(0, endMatch.index) : rest).trim();
+};
+
+const parseKiroUsage = (raw: string): ParsedUsage => {
 	const text = stripAnsi(raw);
-	const plan = text.match(/resets on\s+[0-9-]+\s*\|\s*([^\r\n]+)/i)?.[1]?.trim() ?? 'kiro';
+	const plan = text.match(/resets on\s+[0-9-]+\s*\|\s*([^\r\n]+)/i)?.[1]?.trim() ?? 'Kiro usage';
 	const reset = text.match(/resets on\s+([0-9-]+)/i)?.[1]?.trim() ?? 'unknown';
 	const credits = text.match(/credits\s*\(([^)]+)\)/i)?.[1]?.trim() ?? 'unknown';
-	const percentValue = Number(text.match(/(\d+(?:\.\d+)?)\s*%/)?.[1] ?? NaN);
-	const percent = Number.isFinite(percentValue) ? Math.max(0, Math.min(100, percentValue)) : 0;
+	const percent = parsePercent(text.match(/(\d+(?:\.\d+)?)\s*%/)?.[1]);
 	const overages = text.match(/overages:\s*([^\r\n]+)/i)?.[1]?.trim() ?? 'unknown';
 
-	return { plan, reset, credits, percent, overages };
+	return {
+		title: plan,
+		summary: formatPercent(percent),
+		bars: [
+			{ label: 'Usage', percent, detail: `resets ${reset}` }
+		],
+		metrics: [
+			{ label: 'credits', value: credits },
+			{ label: 'resets', value: reset },
+			{ label: 'overages', value: overages }
+		],
+		note: 'This CLI currently reports a single usage window.'
+	};
+};
+
+const parseClaudeUsage = (raw: string): ParsedUsage => {
+	const text = stripAnsi(raw);
+	const sessionSection = getSection(text, /current session/i, /current week|what's contributing|usage credits|$|est\. to cancel/i);
+	const weekSection = getSection(text, /current week[^\r\n]*/i, /what's contributing|usage credits|$|est\. to cancel/i);
+	const sessionPercent = parsePercent(sessionSection.match(/(\d+(?:\.\d+)?)\s*%\s*used/i)?.[1]);
+	const weekPercent = parsePercent(weekSection.match(/(\d+(?:\.\d+)?)\s*%\s*used/i)?.[1]);
+	const sessionReset = sessionSection.match(/resets\s+([^\r\n]+)/i)?.[1]?.trim() ?? 'unknown';
+	const weekReset = weekSection.match(/resets\s+([^\r\n]+)/i)?.[1]?.trim() ?? 'unknown';
+
+	return {
+		title: 'Claude usage',
+		summary: `${formatPercent(weekPercent)} week`,
+		bars: [
+			{ label: 'Current session', percent: sessionPercent, detail: `resets ${sessionReset}` },
+			{ label: 'Current week', percent: weekPercent, detail: `resets ${weekReset}` }
+		],
+		metrics: [
+			{ label: 'session', value: `${formatPercent(sessionPercent)} used` },
+			{ label: 'session reset', value: sessionReset },
+			{ label: 'week reset', value: weekReset }
+		]
+	};
+};
+
+const parseUsage = (snapshot: CliUsageSnapshot): ParsedUsage | undefined => {
+	const kind = getUsageAgentKind(snapshot.agentLabel);
+	if (kind === 'claude') {
+		return parseClaudeUsage(snapshot.raw);
+	}
+	if (kind === 'kiro') {
+		return parseKiroUsage(snapshot.raw);
+	}
+	return undefined;
 };
 
 const renderUsageMessage = (host: HTMLElement, title: string, detail: string) => {
@@ -81,6 +178,57 @@ const renderUsageMessage = (host: HTMLElement, title: string, detail: string) =>
 	setText(host, '#useUsageMessageDetail', detail);
 };
 
+const createUsageBar = (bar: UsageBar) => {
+	const item = document.createElement('div');
+	item.className = 'use-usage-bar-item';
+
+	const header = document.createElement('div');
+	header.className = 'use-usage-bar-head';
+
+	const label = document.createElement('strong');
+	label.textContent = bar.label;
+	label.title = bar.label;
+
+	const value = document.createElement('span');
+	value.textContent = `${formatPercent(bar.percent)} used`;
+	value.title = value.textContent;
+
+	header.append(label, value);
+
+	const track = document.createElement('div');
+	track.className = 'use-usage-bar';
+	track.setAttribute('aria-hidden', 'true');
+
+	const fill = document.createElement('span');
+	fill.style.width = `${clampPercent(bar.percent)}%`;
+	track.append(fill);
+
+	item.append(header, track);
+
+	if (bar.detail) {
+		const detail = document.createElement('div');
+		detail.className = 'use-usage-bar-detail';
+		detail.textContent = bar.detail;
+		detail.title = bar.detail;
+		item.append(detail);
+	}
+
+	return item;
+};
+
+const createUsageMetric = (metric: UsageMetric) => {
+	const item = document.createElement('div');
+	const label = document.createElement('span');
+	const value = document.createElement('strong');
+
+	label.textContent = metric.label;
+	value.textContent = metric.value;
+	value.title = metric.value;
+	item.append(label, value);
+
+	return item;
+};
+
 const renderUsageSnapshot = (host: HTMLElement, snapshot: CliUsageSnapshot | undefined) => {
 	if (!snapshot) {
 		const agent = getActiveAgentLabel();
@@ -88,23 +236,32 @@ const renderUsageSnapshot = (host: HTMLElement, snapshot: CliUsageSnapshot | und
 		return;
 	}
 
-	if (!snapshot.agentLabel.toLowerCase().includes('kiro')) {
+	const parsed = parseUsage(snapshot);
+	if (!parsed) {
 		renderUsageMessage(host, 'Not configured', snapshot.agentLabel);
 		return;
 	}
 
-	const parsed = parseKiroUsage(snapshot.raw);
 	setHidden(host, '#useUsageMessage', true);
 	setHidden(host, '#useUsageResult', false);
-	setText(host, '#useUsagePlan', parsed.plan);
-	setText(host, '#useUsageCredits', parsed.credits);
-	setText(host, '#useUsagePercent', `${parsed.percent.toFixed(1)}%`);
-	setText(host, '#useUsageReset', parsed.reset);
-	setText(host, '#useUsageOverages', parsed.overages);
+	setText(host, '#useUsageTitle', parsed.title);
+	setText(host, '#useUsageSummary', parsed.summary);
 
-	const bar = host.querySelector<HTMLElement>('#useUsageBar');
-	if (bar) {
-		bar.style.width = `${parsed.percent}%`;
+	const bars = host.querySelector<HTMLElement>('#useUsageBars');
+	if (bars) {
+		bars.replaceChildren(...parsed.bars.map(createUsageBar));
+	}
+
+	const note = host.querySelector<HTMLElement>('#useUsageNote');
+	if (note) {
+		note.hidden = !parsed.note;
+		note.textContent = parsed.note ?? '';
+		note.title = parsed.note ?? '';
+	}
+
+	const meta = host.querySelector<HTMLElement>('#useUsageMeta');
+	if (meta) {
+		meta.replaceChildren(...parsed.metrics.map(createUsageMetric));
 	}
 };
 

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -157,13 +157,27 @@ const renderUseState = (host: HTMLElement, context: ToolContext) => {
 
 export const mountUsePanel = (host: HTMLElement, context: ToolContext) => {
 	ensureStyles();
+	let shouldDismissCliUsageView = false;
+	let didDismissCliUsageView = false;
 
 	const template = document.createElement('template');
 	template.innerHTML = (useHtml as unknown as string).trim();
 	host.replaceChildren(template.content.cloneNode(true));
 
+	const dismissCliUsageView = () => {
+		if (!shouldDismissCliUsageView || didDismissCliUsageView) {
+			return;
+		}
+
+		didDismissCliUsageView = true;
+		context.dismissUsageView?.();
+	};
+
 	const closeBtn = host.querySelector<HTMLButtonElement>('#closeUseBtn');
-	closeBtn?.addEventListener('click', () => context.close());
+	closeBtn?.addEventListener('click', () => {
+		dismissCliUsageView();
+		context.close();
+	});
 
 	const refreshBtn = host.querySelector<HTMLButtonElement>('#useRefreshBtn');
 	refreshBtn?.addEventListener('click', () => {
@@ -172,10 +186,12 @@ export const mountUsePanel = (host: HTMLElement, context: ToolContext) => {
 			return;
 		}
 
+		shouldDismissCliUsageView = true;
 		setRefreshState(host, true);
 		void context.requestUsage()
 			.then((snapshot) => renderUsageSnapshot(host, snapshot))
 			.catch((error) => {
+				shouldDismissCliUsageView = false;
 				const message = error instanceof Error ? error.message : 'Usage refresh failed.';
 				renderUsageMessage(host, 'Refresh failed', message);
 			})
@@ -185,5 +201,8 @@ export const mountUsePanel = (host: HTMLElement, context: ToolContext) => {
 	renderUseState(host, context);
 	renderUsageSnapshot(host, context.getUsageSnapshot?.());
 	const interval = window.setInterval(() => renderUseState(host, context), refreshIntervalMs);
-	return () => window.clearInterval(interval);
+	return () => {
+		window.clearInterval(interval);
+		dismissCliUsageView();
+	};
 };

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -200,7 +200,7 @@ const createUsageBar = (bar: UsageBar) => {
 	track.setAttribute('aria-hidden', 'true');
 
 	const fill = document.createElement('span');
-	fill.style.width = `${clampPercent(bar.percent)}%`;
+	fill.style.width = '0%';
 	track.append(fill);
 
 	item.append(header, track);
@@ -243,6 +243,7 @@ const renderUsageSnapshot = (host: HTMLElement, snapshot: CliUsageSnapshot | und
 	}
 
 	setHidden(host, '#useUsageMessage', true);
+	const result = host.querySelector<HTMLElement>('#useUsageResult');
 	setHidden(host, '#useUsageResult', false);
 	setText(host, '#useUsageTitle', parsed.title);
 	setText(host, '#useUsageSummary', parsed.summary);
@@ -262,6 +263,26 @@ const renderUsageSnapshot = (host: HTMLElement, snapshot: CliUsageSnapshot | und
 	const meta = host.querySelector<HTMLElement>('#useUsageMeta');
 	if (meta) {
 		meta.replaceChildren(...parsed.metrics.map(createUsageMetric));
+	}
+
+	// Nice appear transition + animated bar fills (prevents jarring pop-in)
+	if (result) {
+		result.style.opacity = '0';
+		requestAnimationFrame(() => {
+			result.style.opacity = '1';
+		});
+	}
+
+	// Trigger the width transitions on the freshly created bars
+	if (bars) {
+		requestAnimationFrame(() => {
+			const fills = bars.querySelectorAll<HTMLElement>('.use-usage-bar span');
+			parsed.bars.forEach((bar, i) => {
+				if (fills[i]) {
+					fills[i].style.width = `${clampPercent(bar.percent)}%`;
+				}
+			});
+		});
 	}
 };
 
@@ -360,7 +381,11 @@ export const mountUsePanel = (host: HTMLElement, context: ToolContext) => {
 
 		isRefreshingUsage = true;
 		shouldDismissCliUsageView = true;
-		renderUsageMessage(host, 'Loading usage', commandLabel);
+
+		// No text in the card during loading — rely on the button ("Loading" + spinner)
+		// and the card's sweep animation + reserved min-height for visual feedback.
+		setHidden(host, '#useUsageMessage', true);
+		setHidden(host, '#useUsageResult', true);
 		setRefreshState(host, true);
 		void context.requestUsage()
 			.then((snapshot) => {

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -78,7 +78,6 @@ const renderUseState = (host: HTMLElement, context: ToolContext) => {
 	setText(host, '#useAgentName', agent);
 	setText(host, '#useStatusValue', status);
 	setText(host, '#useOpenFor', formatOpenDuration(context.getActiveSessionCreatedAt?.()));
-	setText(host, '#useTokensLeft', '—');
 	setStatusDot(host, status);
 };
 

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -42,7 +42,7 @@ const setHidden = (host: HTMLElement, selector: string, hidden: boolean) => {
 
 const stripAnsi = (value: string) => value.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
 
-type UsageAgentKind = 'claude' | 'kiro';
+type UsageAgentKind = 'claude' | 'codex' | 'kiro';
 
 type UsageBar = {
 	label: string;
@@ -84,15 +84,22 @@ const getUsageAgentKind = (agentLabel: string): UsageAgentKind | undefined => {
 	if (lower.includes('claude')) {
 		return 'claude';
 	}
+	if (lower.includes('codex')) {
+		return 'codex';
+	}
 	if (lower.includes('kiro')) {
 		return 'kiro';
 	}
 	return undefined;
 };
 
-const getUsageCommandLabel = (agentLabel: string) => (
-	getUsageAgentKind(agentLabel) ? '/usage' : 'not configured'
-);
+const getUsageCommandLabel = (agentLabel: string) => {
+	const kind = getUsageAgentKind(agentLabel);
+	if (kind === 'codex') {
+		return '/status';
+	}
+	return kind ? '/usage' : 'not configured';
+};
 
 const clampPercent = (value: number) => (
 	Number.isFinite(value) ? Math.max(0, Math.min(100, value)) : 0
@@ -160,10 +167,116 @@ const parseClaudeUsage = (raw: string): ParsedUsage => {
 	};
 };
 
+const getCleanLine = (line: string) => line
+	.replace(/[│┃║|]/g, ' ')
+	.replace(/\s+/g, ' ')
+	.trim();
+
+const titleCase = (value: string) => value
+	.replace(/[_-]+/g, ' ')
+	.replace(/\b\w/g, (char) => char.toUpperCase())
+	.trim();
+
+const parseCompactNumber = (value: string) => Number(value.replace(/[,_\s]/g, ''));
+
+const getCodexPercentBars = (text: string): UsageBar[] => {
+	const lines = text.split(/\r?\n/).map(getCleanLine).filter(Boolean);
+	const bars: UsageBar[] = [];
+
+	for (const line of lines) {
+		const percentMatch = line.match(/(\d+(?:\.\d+)?)\s*%\s*(used|remaining|left)?/i);
+		if (!percentMatch) {
+			continue;
+		}
+
+		const rawPercent = parsePercent(percentMatch[1]);
+		const mode = percentMatch[2]?.toLowerCase();
+		const percent = mode === 'remaining' || mode === 'left' ? 100 - rawPercent : rawPercent;
+		const labelSource = line
+			.replace(percentMatch[0], '')
+			.replace(/\b(used|remaining|left)\b/gi, '')
+			.replace(/[:•·-]+$/g, '')
+			.trim();
+		const label = labelSource ? titleCase(labelSource) : 'Status';
+		const detail = mode === 'remaining' || mode === 'left'
+			? `${formatPercent(rawPercent)} ${mode}`
+			: undefined;
+
+		bars.push({ label, percent, detail });
+	}
+
+	return bars.slice(0, 2);
+};
+
+const getCodexTokenBar = (text: string): UsageBar | undefined => {
+	const tokenLine = text
+		.split(/\r?\n/)
+		.map(getCleanLine)
+		.find((line) => /(token|context|usage)/i.test(line) && /(?:\d[\d,_\s]*)\s*(?:\/|of)\s*(?:\d[\d,_\s]*)/i.test(line));
+	const match = tokenLine?.match(/(\d[\d,_\s]*)\s*(?:\/|of)\s*(\d[\d,_\s]*)/i);
+	if (!match) {
+		return undefined;
+	}
+
+	const used = parseCompactNumber(match[1]);
+	const total = parseCompactNumber(match[2]);
+	if (!Number.isFinite(used) || !Number.isFinite(total) || total <= 0) {
+		return undefined;
+	}
+
+	return {
+		label: /context/i.test(tokenLine ?? '') ? 'Context' : 'Tokens',
+		percent: clampPercent((used / total) * 100),
+		detail: `${match[1].trim()} of ${match[2].trim()}`
+	};
+};
+
+const getCodexMetric = (text: string, label: string, pattern: RegExp): UsageMetric | undefined => {
+	const value = text.match(pattern)?.[1]?.trim();
+	if (!value) {
+		return undefined;
+	}
+	return { label, value };
+};
+
+const parseCodexUsage = (raw: string): ParsedUsage => {
+	const text = stripAnsi(raw);
+	const bars = getCodexPercentBars(text);
+	const tokenBar = bars.length === 0 ? getCodexTokenBar(text) : undefined;
+	if (tokenBar) {
+		bars.push(tokenBar);
+	}
+
+	const metrics = [
+		getCodexMetric(text, 'model', /\bmodel\s*[:=]\s*([^\r\n]+)/i),
+		getCodexMetric(text, 'approval', /\bapproval(?:s)?\s*[:=]\s*([^\r\n]+)/i),
+		getCodexMetric(text, 'sandbox', /\bsandbox\s*[:=]\s*([^\r\n]+)/i)
+	].filter((metric): metric is UsageMetric => !!metric).slice(0, 3);
+
+	return {
+		title: 'Codex status',
+		summary: bars[0] ? `${formatPercent(bars[0].percent)} used` : '/status',
+		bars: bars.length > 0 ? bars : [
+			{ label: 'Status', percent: 0, detail: 'No usage percentage found in /status output' }
+		],
+		metrics: metrics.length > 0 ? metrics : [
+			{ label: 'command', value: '/status' },
+			{ label: 'usage', value: bars.length > 0 ? 'detected' : 'not reported' },
+			{ label: 'source', value: 'Codex CLI' }
+		],
+		note: bars.length > 1
+			? undefined
+			: 'Codex status output may expose one usage window or only environment status.'
+	};
+};
+
 const parseUsage = (snapshot: CliUsageSnapshot): ParsedUsage | undefined => {
 	const kind = getUsageAgentKind(snapshot.agentLabel);
 	if (kind === 'claude') {
 		return parseClaudeUsage(snapshot.raw);
+	}
+	if (kind === 'codex') {
+		return parseCodexUsage(snapshot.raw);
 	}
 	if (kind === 'kiro') {
 		return parseKiroUsage(snapshot.raw);

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -149,7 +149,7 @@ const renderUseState = (host: HTMLElement, context: ToolContext) => {
 	const agent = getText('cli-terminal-label', 'CLI');
 	const { status } = getStatusParts();
 
-	setText(host, '#useAgentName', agent);
+	setText(host, '#useModalTitle', agent);
 	setText(host, '#useStatusValue', status);
 	setText(host, '#useOpenFor', formatOpenDuration(context.getActiveSessionCreatedAt?.()));
 	setStatusDot(host, status);

--- a/src/clihub/webview/tools/modal-use/use.ts
+++ b/src/clihub/webview/tools/modal-use/use.ts
@@ -3,7 +3,7 @@ import useHtml from './components/use.html';
 import type { ToolContext } from '../tools';
 
 const stylesId = 'cli-use-panel-styles';
-const refreshIntervalMs = 700;
+const refreshIntervalMs = 1000;
 
 const ensureStyles = () => {
 	if (document.getElementById(stylesId)) {
@@ -56,21 +56,29 @@ const setStatusDot = (host: HTMLElement, status: string) => {
 	dot.classList.toggle('is-error', status === 'error');
 };
 
+const formatOpenDuration = (createdAt: number | undefined) => {
+	if (!createdAt) {
+		return '--:--:--';
+	}
+
+	const totalSeconds = Math.max(0, Math.floor((Date.now() - createdAt) / 1000));
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+
+	return [hours, minutes, seconds]
+		.map((part) => String(part).padStart(2, '0'))
+		.join(':');
+};
+
 const renderUseState = (host: HTMLElement, context: ToolContext) => {
 	const agent = getText('cli-terminal-label', 'CLI');
-	const command = getText('cli-terminal-badge', 'none');
-	const { status, workspace } = getStatusParts();
-	const sessionId = context.getActiveSessionId?.() ?? 'none';
-	const modelName = context.getActiveModelName?.() ?? 'unknown';
-	const filterEnabled = document.querySelector<HTMLInputElement>('#cli-prompt-filter-toggle')?.checked === true;
+	const { status } = getStatusParts();
 
 	setText(host, '#useAgentName', agent);
 	setText(host, '#useStatusValue', status);
-	setText(host, '#useSessionId', sessionId === 'none' ? sessionId : sessionId.slice(0, 8));
-	setText(host, '#useModelName', modelName);
-	setText(host, '#useWorkspace', workspace);
-	setText(host, '#useCommand', command);
-	setText(host, '#useFilterState', filterEnabled ? 'on' : 'off');
+	setText(host, '#useOpenFor', formatOpenDuration(context.getActiveSessionCreatedAt?.()));
+	setText(host, '#useTokensLeft', '—');
 	setStatusDot(host, status);
 };
 

--- a/src/clihub/webview/tools/tools.ts
+++ b/src/clihub/webview/tools/tools.ts
@@ -3,8 +3,9 @@ import { mountPromptPanel } from './modal-prompt/prompt';
 import type { ImageAttachment, PromptTranslateRequest, PromptTranslateResult, FileMentionEntry, SpellIssue, WorkspaceSkill } from '../../shared/prompt';
 import type { VoiceState } from '../../shared/voice/voice-types';
 import { mountTranslatorPanel } from './modal-translator/translator';
+import { mountUsePanel } from './modal-use/use';
 
-export type ToolId = 'translate' | 'keymaps' | 'prompt';
+export type ToolId = 'translate' | 'keymaps' | 'prompt' | 'use';
 
 export type ToolContext = {
 	close: () => void;
@@ -57,7 +58,8 @@ const applyStyles = (element: HTMLElement, styles: Partial<CSSStyleDeclaration>)
 const toolMounts: Record<ToolId, ToolMount> = {
 	keymaps: mountKeymapsPanel,
 	prompt: mountPromptPanel,
-	translate: mountTranslatorPanel
+	translate: mountTranslatorPanel,
+	use: mountUsePanel
 };
 
 	export const createToolsController = ({

--- a/src/clihub/webview/tools/tools.ts
+++ b/src/clihub/webview/tools/tools.ts
@@ -162,6 +162,7 @@ export const createToolsController = ({
 			alignItems: 'center',
 			justifyContent: 'center',
 			width: 'min(580px, calc(100% - 32px))',
+			height: 'calc(100% - 32px)',
 			maxHeight: 'calc(100% - 32px)',
 			boxSizing: 'border-box'
 		});

--- a/src/clihub/webview/tools/tools.ts
+++ b/src/clihub/webview/tools/tools.ts
@@ -7,11 +7,21 @@ import { mountUsePanel } from './modal-use/use';
 
 export type ToolId = 'translate' | 'keymaps' | 'prompt' | 'use';
 
+export type CliUsageSnapshot = {
+	sessionId: string;
+	agentLabel: string;
+	command: string;
+	raw: string;
+	requestedAt: number;
+};
+
 export type ToolContext = {
 	close: () => void;
 	getActiveSessionId?: () => string | undefined;
 	getActiveSessionCreatedAt?: () => number | undefined;
 	getActiveModelName?: () => string | undefined;
+	getUsageSnapshot?: () => CliUsageSnapshot | undefined;
+	requestUsage?: () => Promise<CliUsageSnapshot>;
 	sendToActiveSession?: (text: string, options?: { paste?: boolean; submit?: boolean }) => void;
 	translatePrompt?: (request: PromptTranslateRequest) => Promise<PromptTranslateResult>;
 	getTerminalSelection?: () => string;
@@ -33,6 +43,8 @@ export type ToolsControllerOptions = {
 	getActiveSessionId?: () => string | undefined;
 	getActiveSessionCreatedAt?: () => number | undefined;
 	getActiveModelName?: () => string | undefined;
+	getUsageSnapshot?: () => CliUsageSnapshot | undefined;
+	requestUsage?: () => Promise<CliUsageSnapshot>;
 	sendToActiveSession?: (text: string, options?: { paste?: boolean; submit?: boolean }) => void;
 	translatePrompt?: (request: PromptTranslateRequest) => Promise<PromptTranslateResult>;
 	getTerminalSelection?: () => string;
@@ -64,107 +76,111 @@ const toolMounts: Record<ToolId, ToolMount> = {
 	use: mountUsePanel
 };
 
-	export const createToolsController = ({
-		container,
-		getActiveSessionId,
-		getActiveSessionCreatedAt,
-		getActiveModelName,
-		sendToActiveSession,
-		translatePrompt,
-		getTerminalSelection,
-		preparePromptWithAttachments,
-		requestWorkspaceFiles,
-		requestWorkspaceSkills,
-		openCreateSkill,
-		requestSpellcheck,
-		speakText,
-		stopSpeech,
-		queryVoiceState,
-		onVoiceState
-	}: ToolsControllerOptions) => {
-		let activeModal: HTMLElement | null = null;
-		let currentTool: ToolId | null = null;
-		let activeCleanup: ToolCleanup | null = null;
-	
-		const close = () => {
-			document.removeEventListener('keydown', handleKeyDown);
-			const closingTool = currentTool;
-			activeCleanup?.();
-			activeCleanup = null;
-			if (closingTool === 'translate') {
-				stopSpeech?.();
-			}
-			activeModal?.replaceChildren();
-			activeModal?.remove();
-			activeModal = null;
-			currentTool = null;
-		};
-	
-		const handleKeyDown = (event: KeyboardEvent) => {
-			if (event.key === 'Escape') {
-				event.preventDefault();
+export const createToolsController = ({
+	container,
+	getActiveSessionId,
+	getActiveSessionCreatedAt,
+	getActiveModelName,
+	getUsageSnapshot,
+	requestUsage,
+	sendToActiveSession,
+	translatePrompt,
+	getTerminalSelection,
+	preparePromptWithAttachments,
+	requestWorkspaceFiles,
+	requestWorkspaceSkills,
+	openCreateSkill,
+	requestSpellcheck,
+	speakText,
+	stopSpeech,
+	queryVoiceState,
+	onVoiceState
+}: ToolsControllerOptions) => {
+	let activeModal: HTMLElement | null = null;
+	let currentTool: ToolId | null = null;
+	let activeCleanup: ToolCleanup | null = null;
+
+	const close = () => {
+		document.removeEventListener('keydown', handleKeyDown);
+		const closingTool = currentTool;
+		activeCleanup?.();
+		activeCleanup = null;
+		if (closingTool === 'translate') {
+			stopSpeech?.();
+		}
+		activeModal?.replaceChildren();
+		activeModal?.remove();
+		activeModal = null;
+		currentTool = null;
+	};
+
+	const handleKeyDown = (event: KeyboardEvent) => {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			close();
+		}
+	};
+
+	const open = (tool: ToolId) => {
+		close();
+
+		const modal = document.createElement('div');
+		modal.id = modalId;
+		modal.setAttribute('role', 'dialog');
+		modal.setAttribute('aria-modal', 'true');
+		modal.setAttribute('aria-label', tool);
+
+		applyStyles(modal, {
+			position: 'absolute',
+			inset: '0',
+			zIndex: '1000',
+			display: 'flex',
+			alignItems: 'center',
+			justifyContent: 'center',
+			background: 'rgba(0, 0, 0, 0.38)',
+			backdropFilter: 'blur(16px)'
+		});
+
+		const host = document.createElement('div');
+		applyStyles(host, {
+			display: 'flex',
+			width: 'min(580px, calc(100% - 32px))',
+			maxHeight: 'calc(100% - 32px)',
+			boxSizing: 'border-box'
+		});
+		modal.append(host);
+
+		modal.addEventListener('click', (event) => {
+			if (event.target === modal && tool === 'keymaps') {
 				close();
 			}
-		};
-	
-		const open = (tool: ToolId) => {
-			close();
-	
-			const modal = document.createElement('div');
-			modal.id = modalId;
-			modal.setAttribute('role', 'dialog');
-			modal.setAttribute('aria-modal', 'true');
-			modal.setAttribute('aria-label', tool);
-	
-			applyStyles(modal, {
-				position: 'absolute',
-				inset: '0',
-				zIndex: '1000',
-				display: 'flex',
-				alignItems: 'center',
-				justifyContent: 'center',
-				background: 'rgba(0, 0, 0, 0.38)',
-				backdropFilter: 'blur(16px)'
-			});
-	
-			const host = document.createElement('div');
-			applyStyles(host, {
-				display: 'flex',
-				width: 'min(580px, calc(100% - 32px))',
-				maxHeight: 'calc(100% - 32px)',
-				boxSizing: 'border-box'
-			});
-			modal.append(host);
-	
-			modal.addEventListener('click', (event) => {
-				if (event.target === modal && tool === 'keymaps') {
-					close();
-				}
-			});
-	
-			host.addEventListener('click', (event) => {
-				event.stopPropagation();
-			});
-	
-				const cleanup = toolMounts[tool](host, {
-					close,
-					getActiveSessionId,
-					getActiveSessionCreatedAt,
-					getActiveModelName,
-					sendToActiveSession,
-					translatePrompt,
-					getTerminalSelection,
-					preparePromptWithAttachments,
-					requestWorkspaceFiles,
-					requestWorkspaceSkills,
-					openCreateSkill,
-					requestSpellcheck,
-					speakText,
-					stopSpeech,
-					queryVoiceState,
-					onVoiceState
-				});
-				activeCleanup = typeof cleanup === 'function' ? cleanup : null;
+		});
+
+		host.addEventListener('click', (event) => {
+			event.stopPropagation();
+		});
+
+		const cleanup = toolMounts[tool](host, {
+			close,
+			getActiveSessionId,
+			getActiveSessionCreatedAt,
+			getActiveModelName,
+			getUsageSnapshot,
+			requestUsage,
+			sendToActiveSession,
+			translatePrompt,
+			getTerminalSelection,
+			preparePromptWithAttachments,
+			requestWorkspaceFiles,
+			requestWorkspaceSkills,
+			openCreateSkill,
+			requestSpellcheck,
+			speakText,
+			stopSpeech,
+			queryVoiceState,
+			onVoiceState
+		});
+		activeCleanup = typeof cleanup === 'function' ? cleanup : null;
 
 		container.append(modal);
 		document.addEventListener('keydown', handleKeyDown);

--- a/src/clihub/webview/tools/tools.ts
+++ b/src/clihub/webview/tools/tools.ts
@@ -203,14 +203,21 @@ export const createToolsController = ({
 
 		container.append(modal);
 
-		// Make the dialog focusable and move focus into it. This is the key fix for
-		// "Esc does not close on first open": the xterm underneath would otherwise
-		// keep focus and swallow (or turn into terminal input) the Escape key before
-		// our document listener could see it. Focusing the modal ensures the event
-		// targets something inside the overlay.
 		modal.tabIndex = -1;
-		// Focus after paint so the content (close button etc.) is ready.
-		requestAnimationFrame(() => modal.focus());
+
+		// Focus strategy on open:
+		// - For the Prompt modal (the "chat"), explicitly focus the textarea so the
+		//   cursor is ready for immediate typing.
+		// - For other tools, focus the dialog container itself (helps Esc trapping
+		//   and keeps focus inside the overlay instead of the terminal underneath).
+		requestAnimationFrame(() => {
+			const promptInput = host.querySelector<HTMLTextAreaElement>('#promptInput');
+			if (promptInput && !promptInput.disabled) {
+				promptInput.focus();
+			} else {
+				modal.focus();
+			}
+		});
 
 		// Capture phase + stopPropagation so Escape is intercepted even if the
 		// terminal still has some internal key handling.

--- a/src/clihub/webview/tools/tools.ts
+++ b/src/clihub/webview/tools/tools.ts
@@ -10,6 +10,7 @@ export type ToolId = 'translate' | 'keymaps' | 'prompt' | 'use';
 export type ToolContext = {
 	close: () => void;
 	getActiveSessionId?: () => string | undefined;
+	getActiveSessionCreatedAt?: () => number | undefined;
 	getActiveModelName?: () => string | undefined;
 	sendToActiveSession?: (text: string, options?: { paste?: boolean; submit?: boolean }) => void;
 	translatePrompt?: (request: PromptTranslateRequest) => Promise<PromptTranslateResult>;
@@ -30,6 +31,7 @@ type ToolMount = (host: HTMLElement, context: ToolContext) => void | ToolCleanup
 export type ToolsControllerOptions = {
 	container: HTMLElement;
 	getActiveSessionId?: () => string | undefined;
+	getActiveSessionCreatedAt?: () => number | undefined;
 	getActiveModelName?: () => string | undefined;
 	sendToActiveSession?: (text: string, options?: { paste?: boolean; submit?: boolean }) => void;
 	translatePrompt?: (request: PromptTranslateRequest) => Promise<PromptTranslateResult>;
@@ -65,6 +67,7 @@ const toolMounts: Record<ToolId, ToolMount> = {
 	export const createToolsController = ({
 		container,
 		getActiveSessionId,
+		getActiveSessionCreatedAt,
 		getActiveModelName,
 		sendToActiveSession,
 		translatePrompt,
@@ -146,6 +149,7 @@ const toolMounts: Record<ToolId, ToolMount> = {
 				const cleanup = toolMounts[tool](host, {
 					close,
 					getActiveSessionId,
+					getActiveSessionCreatedAt,
 					getActiveModelName,
 					sendToActiveSession,
 					translatePrompt,

--- a/src/clihub/webview/tools/tools.ts
+++ b/src/clihub/webview/tools/tools.ts
@@ -22,6 +22,7 @@ export type ToolContext = {
 	getActiveModelName?: () => string | undefined;
 	getUsageSnapshot?: () => CliUsageSnapshot | undefined;
 	requestUsage?: () => Promise<CliUsageSnapshot>;
+	dismissUsageView?: () => void;
 	sendToActiveSession?: (text: string, options?: { paste?: boolean; submit?: boolean }) => void;
 	translatePrompt?: (request: PromptTranslateRequest) => Promise<PromptTranslateResult>;
 	getTerminalSelection?: () => string;
@@ -45,6 +46,7 @@ export type ToolsControllerOptions = {
 	getActiveModelName?: () => string | undefined;
 	getUsageSnapshot?: () => CliUsageSnapshot | undefined;
 	requestUsage?: () => Promise<CliUsageSnapshot>;
+	dismissUsageView?: () => void;
 	sendToActiveSession?: (text: string, options?: { paste?: boolean; submit?: boolean }) => void;
 	translatePrompt?: (request: PromptTranslateRequest) => Promise<PromptTranslateResult>;
 	getTerminalSelection?: () => string;
@@ -83,6 +85,7 @@ export const createToolsController = ({
 	getActiveModelName,
 	getUsageSnapshot,
 	requestUsage,
+	dismissUsageView,
 	sendToActiveSession,
 	translatePrompt,
 	getTerminalSelection,
@@ -169,6 +172,7 @@ export const createToolsController = ({
 			getActiveModelName,
 			getUsageSnapshot,
 			requestUsage,
+			dismissUsageView,
 			sendToActiveSession,
 			translatePrompt,
 			getTerminalSelection,

--- a/src/clihub/webview/tools/tools.ts
+++ b/src/clihub/webview/tools/tools.ts
@@ -144,6 +144,8 @@ export const createToolsController = ({
 		const host = document.createElement('div');
 		applyStyles(host, {
 			display: 'flex',
+			alignItems: 'center',
+			justifyContent: 'center',
 			width: 'min(580px, calc(100% - 32px))',
 			maxHeight: 'calc(100% - 32px)',
 			boxSizing: 'border-box'

--- a/src/clihub/webview/tools/tools.ts
+++ b/src/clihub/webview/tools/tools.ts
@@ -35,6 +35,7 @@ export type ToolContext = {
 	stopSpeech?: () => void;
 	queryVoiceState?: () => void;
 	onVoiceState?: (listener: (state: VoiceState, message?: string) => void) => () => void;
+	refocusTerminal?: () => void;
 };
 
 type ToolCleanup = () => void;
@@ -59,6 +60,7 @@ export type ToolsControllerOptions = {
 	stopSpeech?: () => void;
 	queryVoiceState?: () => void;
 	onVoiceState?: (listener: (state: VoiceState, message?: string) => void) => () => void;
+	refocusTerminal?: () => void;
 };
 
 const modalId = 'cli-tools-modal';
@@ -97,14 +99,15 @@ export const createToolsController = ({
 	speakText,
 	stopSpeech,
 	queryVoiceState,
-	onVoiceState
+	onVoiceState,
+	refocusTerminal
 }: ToolsControllerOptions) => {
 	let activeModal: HTMLElement | null = null;
 	let currentTool: ToolId | null = null;
 	let activeCleanup: ToolCleanup | null = null;
 
 	const close = () => {
-		document.removeEventListener('keydown', handleKeyDown);
+		document.removeEventListener('keydown', handleKeyDown, true);
 		const closingTool = currentTool;
 		activeCleanup?.();
 		activeCleanup = null;
@@ -115,11 +118,19 @@ export const createToolsController = ({
 		activeModal?.remove();
 		activeModal = null;
 		currentTool = null;
+
+		// Return focus using the host-provided function (uses real Terminal.focus()
+		// on the xterm instance so input works and no visible focus ring appears
+		// on a container div).
+		requestAnimationFrame(() => {
+			refocusTerminal?.();
+		});
 	};
 
 	const handleKeyDown = (event: KeyboardEvent) => {
 		if (event.key === 'Escape') {
 			event.preventDefault();
+			event.stopPropagation();
 			close();
 		}
 	};
@@ -141,7 +152,8 @@ export const createToolsController = ({
 			alignItems: 'center',
 			justifyContent: 'center',
 			background: 'rgba(0, 0, 0, 0.38)',
-			backdropFilter: 'blur(16px)'
+			backdropFilter: 'blur(16px)',
+			outline: 'none'
 		});
 
 		const host = document.createElement('div');
@@ -184,12 +196,25 @@ export const createToolsController = ({
 			speakText,
 			stopSpeech,
 			queryVoiceState,
-			onVoiceState
+			onVoiceState,
+			refocusTerminal
 		});
 		activeCleanup = typeof cleanup === 'function' ? cleanup : null;
 
 		container.append(modal);
-		document.addEventListener('keydown', handleKeyDown);
+
+		// Make the dialog focusable and move focus into it. This is the key fix for
+		// "Esc does not close on first open": the xterm underneath would otherwise
+		// keep focus and swallow (or turn into terminal input) the Escape key before
+		// our document listener could see it. Focusing the modal ensures the event
+		// targets something inside the overlay.
+		modal.tabIndex = -1;
+		// Focus after paint so the content (close button etc.) is ready.
+		requestAnimationFrame(() => modal.focus());
+
+		// Capture phase + stopPropagation so Escape is intercepted even if the
+		// terminal still has some internal key handling.
+		document.addEventListener('keydown', handleKeyDown, true);
 		activeModal = modal;
 		currentTool = tool;
 	};


### PR DESCRIPTION
This pull request introduces a new "Status/use" tool to the CLI webview interface, adds a keyboard shortcut for quick access, and improves the handling and display of usage/status information for different CLI agents. Additionally, it enhances session tab usability and visual feedback, and refines file listing logic to respect `.gitignore` rules. Below are the most important changes grouped by theme:

**New "Status/use" Tool and Usage Handling:**

* Added the "Status/use" tool to the agent tools popover, including a new keyboard shortcut (`Shift+F4`) and support for opening the tool via both UI and keyboard. (`src/clihub/webview/keymaps.ts`, `src/clihub/webview/panel-tab/tab.html`, `src/clihub/webview/panel-tab/tab.ts`, [[1]](diffhunk://#diff-7d4c9990ff8a8189070976abca569f95de36dce86ec2cec8178162e6d6d1bb46R74-R81) [[2]](diffhunk://#diff-18bfcbf93fa169079d5b526a81d8c47637dad055aaf4c5588470a0367c2e70dcL25-R26) [[3]](diffhunk://#diff-18bfcbf93fa169079d5b526a81d8c47637dad055aaf4c5588470a0367c2e70dcR222-R228) [[4]](diffhunk://#diff-49dff9b44a9cb911cacef589265e1e90f22143b9a027a0f9d7c391bdb9595cecL23-R23) [[5]](diffhunk://#diff-49dff9b44a9cb911cacef589265e1e90f22143b9a027a0f9d7c391bdb9595cecR329-R334) [[6]](diffhunk://#diff-49dff9b44a9cb911cacef589265e1e90f22143b9a027a0f9d7c391bdb9595cecL445-R465)
* Implemented logic to issue `/usage` or `/status` commands to the underlying agent depending on the agent type, collect the output, and manage request timeouts and state. (`src/clihub/webview/panel-terminal/terminal.ts`, [[1]](diffhunk://#diff-dc41db184e9ce5e27d90bc455511730e29d03fcfff82d6c80c9616402a86316bR51-R74) [[2]](diffhunk://#diff-dc41db184e9ce5e27d90bc455511730e29d03fcfff82d6c80c9616402a86316bR201-R332) [[3]](diffhunk://#diff-dc41db184e9ce5e27d90bc455511730e29d03fcfff82d6c80c9616402a86316bR462-R467) [[4]](diffhunk://#diff-dc41db184e9ce5e27d90bc455511730e29d03fcfff82d6c80c9616402a86316bR478-R485)
* Provided an API for the tools controller to request, retrieve, and dismiss usage snapshots for the active session. (`src/clihub/webview/panel-terminal/terminal.ts`, [[1]](diffhunk://#diff-dc41db184e9ce5e27d90bc455511730e29d03fcfff82d6c80c9616402a86316bR462-R467) [[2]](diffhunk://#diff-dc41db184e9ce5e27d90bc455511730e29d03fcfff82d6c80c9616402a86316bR478-R485)

**Session Tab Usability and Visual Feedback:**

* Enhanced the session tab UI to support "alt-close mode": holding `Alt` while hovering over session tabs visually highlights them for closing, and clicking closes the session instead of switching. (`src/clihub/webview/panel-tab/tab.css`, `src/clihub/webview/panel-tab/tab.ts`, [[1]](diffhunk://#diff-275e573ba9f1bb06567e1f8ca9b8c207c2e67ba02d995567f1ac75d62dcdc02fR871-R903) [[2]](diffhunk://#diff-49dff9b44a9cb911cacef589265e1e90f22143b9a027a0f9d7c391bdb9595cecR272) [[3]](diffhunk://#diff-49dff9b44a9cb911cacef589265e1e90f22143b9a027a0f9d7c391bdb9595cecR379-R391) [[4]](diffhunk://#diff-49dff9b44a9cb911cacef589265e1e90f22143b9a027a0f9d7c391bdb9595cecL657-R689)
* Adjusted the agent tools popover styling for improved appearance and alignment. (`src/clihub/webview/panel-tab/tab.css`, [src/clihub/webview/panel-tab/tab.cssL744-R746](diffhunk://#diff-275e573ba9f1bb06567e1f8ca9b8c207c2e67ba02d995567f1ac75d62dcdc02fL744-R746))

**File Listing and `.gitignore` Compliance:**

* Updated file listing logic to parse the workspace `.gitignore` and exclude ignored files and directories from the list, improving relevance and reducing clutter. (`src/clihub/host/workspace.ts`, [[1]](diffhunk://#diff-be139c05aecc8f001b77ef5daddb6b817c388ba19f68be04938c4a8dedcf1071R11-R19) [[2]](diffhunk://#diff-be139c05aecc8f001b77ef5daddb6b817c388ba19f68be04938c4a8dedcf1071R111) [[3]](diffhunk://#diff-be139c05aecc8f001b77ef5daddb6b817c388ba19f68be04938c4a8dedcf1071L120-R130) [[4]](diffhunk://#diff-be139c05aecc8f001b77ef5daddb6b817c388ba19f68be04938c4a8dedcf1071R148-R151) [[5]](diffhunk://#diff-be139c05aecc8f001b77ef5daddb6b817c388ba19f68be04938c4a8dedcf1071R190-R342)

**Terminal Focus and Accessibility:**

* Prevented unwanted focus outlines on the terminal pane for a cleaner user experience, especially after closing tool modals or navigating via keyboard. (`src/clihub/webview/panel-terminal/terminal.css`, [src/clihub/webview/panel-terminal/terminal.cssR108-R118](diffhunk://#diff-d9979ee1b2a37a61df72067772865d301f1382c3add21111609eb004199bd50eR108-R118))