### PR TITLE
🛠️ Enhance keyboard shortcuts, UI styles, and personal dictionary

### DIFF
--- a/src/my-cli/core/main.ts
+++ b/src/my-cli/core/main.ts
@@ -130,7 +130,7 @@ export class MyCliViewProvider implements vscode.WebviewViewProvider, vscode.Dis
 			}
 
 			if (message.type === 'cli.openTutorial') {
-				this.openTutorial();
+				void vscode.env.openExternal(vscode.Uri.parse('https://www.gohit.xyz/extension/f1'));
 				return;
 			}
 

--- a/src/my-cli/core/spellcheck/data/personal-mistakes.ts
+++ b/src/my-cli/core/spellcheck/data/personal-mistakes.ts
@@ -31,6 +31,8 @@ export const PERSONAL_MISTAKES: Record<string, string> = {
 	'ocure': 'ocurre',
 	'desactibe': 'desactive',
 	'traducion': 'traduccion',
+	'abarillo': 'amarillo',
+	'aslo': 'as lo',
 
 
     // world 

--- a/src/my-cli/core/spellcheck/data/personal-mistakes.ts
+++ b/src/my-cli/core/spellcheck/data/personal-mistakes.ts
@@ -33,6 +33,7 @@ export const PERSONAL_MISTAKES: Record<string, string> = {
 	'traducion': 'traduccion',
 	'abarillo': 'amarillo',
 	'aslo': 'as lo',
+	'amejorar': 'mejorar',
 
 
     // world 

--- a/src/my-cli/core/spellcheck/data/personal-mistakes.ts
+++ b/src/my-cli/core/spellcheck/data/personal-mistakes.ts
@@ -21,6 +21,7 @@ export const PERSONAL_MISTAKES: Record<string, string> = {
 	'agamoslo': 'hagamoslo',
 	'tine': 'tiene',
 	'aga': 'haga',
+	'txto': 'texto',
 	'amrillo': 'amarillo',
 	'sierto': 'cierto',
 	'agreges': 'agregues',

--- a/src/my-cli/core/spellcheck/data/personal-mistakes.ts
+++ b/src/my-cli/core/spellcheck/data/personal-mistakes.ts
@@ -28,6 +28,7 @@ export const PERSONAL_MISTAKES: Record<string, string> = {
 	'agreges': 'agregues',
 	'promot': 'prompt',
 	'actibe': 'active',
+	'ocure': 'ocurre',
 	'desactibe': 'desactive',
 	'traducion': 'traduccion',
 

--- a/src/my-cli/core/spellcheck/data/personal-mistakes.ts
+++ b/src/my-cli/core/spellcheck/data/personal-mistakes.ts
@@ -21,11 +21,14 @@ export const PERSONAL_MISTAKES: Record<string, string> = {
 	'agamoslo': 'hagamoslo',
 	'tine': 'tiene',
 	'aga': 'haga',
+	'limpes': 'limpies',
 	'txto': 'texto',
 	'amrillo': 'amarillo',
 	'sierto': 'cierto',
 	'agreges': 'agregues',
 	'promot': 'prompt',
+	'actibe': 'active',
+	'desactibe': 'desactive',
 	'traducion': 'traduccion',
 
 

--- a/src/my-cli/core/spellcheck/data/protected-terms.ts
+++ b/src/my-cli/core/spellcheck/data/protected-terms.ts
@@ -1,6 +1,6 @@
 export const PROTECTED_TERMS = new Set<string>([
 	// Word
-	'analizalo', 'banderitas', 'voice-tts', 'voice tts', 'play', 'cositas','autorizacion','automaticamente', 'telemetria', 'especificamente', 'inspirate',	'susténtalo', 'sustentalo', 'redireccionará', 'mobile', 'footer', 'header', 'link', 'mejoralo', 'blur', 'revisalo', 'vistaz', 'peru', 'links', 'google translate', 'dev', 'Mejorame', 'google', 'scroll', 'translate', 'hover', 'copy','Smart', 'hagamoslo', 'agregame', 'cajita', 'keymaps',
+	'analizalo', 'banderitas', 'voice-tts', 'voice tts', 'play', 'cositas','autorizacion','automaticamente', 'telemetria', 'especificamente', 'inspirate',	'susténtalo', 'sustentalo', 'redireccionará', 'mobile', 'footer', 'header', 'link', 'mejoralo', 'blur', 'revisalo', 'vistaz', 'peru', 'links', 'google translate', 'dev', 'Mejorame', 'google', 'scroll', 'translate', 'hover', 'copy','Smart', 'hagamoslo', 'agregame', 'cajita', 'keymaps', 'mejorame', 'hover',
 
 	// Frameworks & libraries
 	'react', 'vue', 'angular', 'svelte', 'solid', 'nextjs', 'nuxt', 'astro', 'remix',

--- a/src/my-cli/webview/global.css
+++ b/src/my-cli/webview/global.css
@@ -230,10 +230,11 @@ body {
 
 .agent-icon-option:hover {
 	z-index: 1;
-	border-color: color-mix(in srgb, var(--accent-color) 46%, transparent);
-	background: color-mix(in srgb, var(--accent-color) 12%, var(--vscode-input-background, rgba(128, 128, 128, 0.1)));
+	border-color: color-mix(in srgb, #b8860b 40%, transparent);
+	background: color-mix(in srgb, #b8860b 10%, var(--vscode-input-background, rgba(128, 128, 128, 0.1)));
 	outline: none;
 	transform: translateY(-1px);
+	box-shadow: 0 2px 10px color-mix(in srgb, #b8860b 12%, transparent);
 }
 
 .agent-icon-option:focus-visible {

--- a/src/my-cli/webview/global.css
+++ b/src/my-cli/webview/global.css
@@ -354,13 +354,13 @@ body.is-smart-mode .agent-icon-option.is-preview .agent-icon-status {
 	padding: 0 4px;
 	height: 14px;
 	border-radius: 4px 0 8px 0;
-	background: #d4d4d8; /* Silver */
-	color: #000000;
+	background: color-mix(in srgb, #3b82f6 15%, transparent);
+	border: 1px solid color-mix(in srgb, #3b82f6 25%, transparent);
+	color: #3b82f6;
 	font-family: var(--font-family);
 	font-size: 9px;
 	font-weight: 700;
 	display: none;
-	box-shadow: 0 1px 2px rgba(0,0,0,0.4);
 	box-sizing: border-box;
 	z-index: 2;
 }

--- a/src/my-cli/webview/global.css
+++ b/src/my-cli/webview/global.css
@@ -587,8 +587,8 @@ body.is-smart-mode .agent-icon-number {
 
 .cli-tutorial-button:hover {
 	color: var(--vscode-button-foreground, #ffffff);
-	background: var(--accent-color);
-	border-color: var(--accent-color);
+	background: #b8860b;
+	border-color: #b8860b;
 }
 
 .cli-tutorial-button:focus-visible {

--- a/src/my-cli/webview/launcher/index.html
+++ b/src/my-cli/webview/launcher/index.html
@@ -36,7 +36,7 @@
 		<div id="agent-icon-palette" class="agent-icon-palette" aria-label="CLI agents" aria-hidden="true"></div>
 
 		<div class="shortcuts">
-			<strong>Tab</strong> toggle &nbsp;<span>| </span>&nbsp;<strong>Alt+CapsLock</strong> Side Panel
+			<strong>Tab</strong> · toggle &nbsp;<span>l </span>&nbsp;<strong>Alt+CapsLock</strong> · side panel
 		</div>
 	</div>
 

--- a/src/my-cli/webview/launcher/index.html
+++ b/src/my-cli/webview/launcher/index.html
@@ -36,7 +36,7 @@
 		<div id="agent-icon-palette" class="agent-icon-palette" aria-label="CLI agents" aria-hidden="true"></div>
 
 		<div class="shortcuts">
-			<strong>Tab</strong> agents &nbsp;<span>| </span>&nbsp;<strong>Alt+CapsLock</strong> Side Panel
+			<strong>Tab</strong> toggle &nbsp;<span>| </span>&nbsp;<strong>Alt+CapsLock</strong> Side Panel
 		</div>
 	</div>
 

--- a/src/my-cli/webview/launcher/index.ts
+++ b/src/my-cli/webview/launcher/index.ts
@@ -99,7 +99,6 @@ let currentIndex = typeof persistedState?.currentIndex === 'number'
 	: 0;
 let selectedModel: LauncherModel | undefined = models.find((model) => model.label === persistedState?.selectedAgent) || models[currentIndex] || models[0];
 let selectedCustomCli = false;
-let paletteOpen = true;
 let invalidInputTimer: ReturnType<typeof setTimeout> | undefined;
 
 const textElement = getRequiredElement<HTMLSpanElement>('ai-model-name');
@@ -289,7 +288,7 @@ const handlePaletteOptionKeydown = (
 
 	if (event.key === 'Tab') {
 		event.preventDefault();
-		setPaletteOpen(false);
+		footerToggle?.click();
 		cliInput.focus();
 		return;
 	}
@@ -302,7 +301,6 @@ const handlePaletteOptionKeydown = (
 
 	if (event.key === 'Escape') {
 		event.preventDefault();
-		setPaletteOpen(false);
 		cliInput.focus();
 		return;
 	}
@@ -319,39 +317,6 @@ const handlePaletteOptionKeydown = (
 	}
 };
 
-const setPaletteOpen = (isOpen: boolean, shouldFocus = false, shouldAnimate = true) => {
-	paletteOpen = isOpen;
-	if (!shouldAnimate) {
-		agentIconPalette.style.transition = 'none';
-	}
-
-	document.body.classList.toggle('has-agent-palette', isOpen);
-	agentIconPalette.classList.toggle('is-open', isOpen);
-	agentIconPalette.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
-	saveLauncherState();
-
-	if (!shouldAnimate) {
-		agentIconPalette.offsetHeight;
-		requestAnimationFrame(() => {
-			agentIconPalette.style.transition = '';
-		});
-	}
-
-	for (const option of Array.from(agentIconPalette.querySelectorAll<HTMLButtonElement>('.agent-icon-option'))) {
-		option.tabIndex = isOpen ? 0 : -1;
-	}
-
-	if (!isOpen) {
-		return;
-	}
-
-	if (shouldFocus) {
-		agentIconPalette.querySelector<HTMLElement>('.agent-icon-option')?.focus();
-	}
-
-	syncPreviewIndicator();
-};
-
 const renderIconPalette = () => {
 	agentIconPalette.replaceChildren();
 
@@ -363,7 +328,7 @@ const renderIconPalette = () => {
 		option.classList.toggle('has-dark-icon', model.darkIcon === true);
 		option.classList.toggle('has-light-icon', model.lightIcon === true);
 		option.type = 'button';
-		option.tabIndex = -1;
+		option.tabIndex = 0;
 		option.dataset.agent = model.label;
 		option.title = model.installed ? model.label : `${model.label} is not installed`;
 		option.setAttribute('aria-label', option.title);
@@ -398,7 +363,7 @@ const renderIconPalette = () => {
 	const customOption = document.createElement('button');
 	customOption.className = 'agent-icon-option agent-icon-option--custom is-installed';
 	customOption.type = 'button';
-	customOption.tabIndex = -1;
+	customOption.tabIndex = 0;
 	customOption.dataset.customCli = 'true';
 	customOption.title = `Open ${customCliLabel}`;
 	customOption.setAttribute('aria-label', customOption.title);
@@ -432,7 +397,10 @@ if (restoreQuery) {
 } else {
 	setSelectedModel(selectedModel, false);
 }
-setPaletteOpen(paletteOpen, false, false);
+document.body.classList.add('has-agent-palette');
+agentIconPalette.classList.add('is-open');
+agentIconPalette.setAttribute('aria-hidden', 'false');
+syncPreviewIndicator();
 
 cliInput.addEventListener('input', () => {
 	const lowerValue = cliInput.value.toLowerCase();
@@ -477,21 +445,13 @@ cliInput.addEventListener('keydown', (event) => {
 	}
 
 	if (event.key === 'Tab') {
-		if (!event.shiftKey) {
-			event.preventDefault();
-			setPaletteOpen(!paletteOpen);
-			return;
-		}
-
-		if (paletteOpen) {
-			event.preventDefault();
-			setPaletteOpen(false);
-		}
+		event.preventDefault();
+		footerToggle?.click();
+		return;
 	}
 
-	if (event.key === 'Escape' && paletteOpen) {
+	if (event.key === 'Escape') {
 		event.preventDefault();
-		setPaletteOpen(false);
 	}
 });
 

--- a/src/my-cli/webview/launcher/index.ts
+++ b/src/my-cli/webview/launcher/index.ts
@@ -99,6 +99,7 @@ let currentIndex = typeof persistedState?.currentIndex === 'number'
 	: 0;
 let selectedModel: LauncherModel | undefined = models.find((model) => model.label === persistedState?.selectedAgent) || models[currentIndex] || models[0];
 let selectedCustomCli = false;
+let savedInputValue = '';
 let invalidInputTimer: ReturnType<typeof setTimeout> | undefined;
 
 const textElement = getRequiredElement<HTMLSpanElement>('ai-model-name');
@@ -286,13 +287,6 @@ const handlePaletteOptionKeydown = (
 	const options = getPaletteOptions();
 	const index = options.indexOf(option);
 
-	if (event.key === 'Tab') {
-		event.preventDefault();
-		footerToggle?.click();
-		cliInput.focus();
-		return;
-	}
-
 	if (event.key === 'Enter' || event.key === ' ') {
 		event.preventDefault();
 		activate();
@@ -426,6 +420,12 @@ cliInput.addEventListener('input', () => {
 });
 
 window.addEventListener('keydown', (event) => {
+	if (event.key === 'Tab') {
+		event.preventDefault();
+		footerToggle?.click();
+		return;
+	}
+
 	if (document.body.classList.contains('is-smart-mode')) {
 		const shortcutMatch = matchAgentShortcut(event);
 		if (shortcutMatch) {
@@ -441,12 +441,6 @@ window.addEventListener('keydown', (event) => {
 cliInput.addEventListener('keydown', (event) => {
 	if (event.key === 'Enter') {
 		openSelectedModel();
-		return;
-	}
-
-	if (event.key === 'Tab') {
-		event.preventDefault();
-		footerToggle?.click();
 		return;
 	}
 
@@ -471,6 +465,18 @@ if (footerToggle && footerToggleLabel) {
 		footerToggleLabel.textContent = isOn
 			? (footerToggleLabel.dataset.on ?? 'Smart + Skills')
 			: (footerToggleLabel.dataset.off ?? '');
+
+		if (isOn) {
+			savedInputValue = cliInput.value;
+			cliInput.value = '';
+			cliInput.disabled = true;
+			cliInput.dispatchEvent(new Event('input'));
+		} else {
+			cliInput.disabled = false;
+			cliInput.value = savedInputValue;
+			cliInput.dispatchEvent(new Event('input'));
+			cliInput.focus();
+		}
 	});
 }
 

--- a/src/my-cli/webview/launcher/index.ts
+++ b/src/my-cli/webview/launcher/index.ts
@@ -1,4 +1,5 @@
 import { getAgentSlug as resolveAgentSlug } from '../../shared/agents';
+import { matchAgentShortcut } from '../../../shared/keymaps/cli';
 
 type VsCodeApi = {
 	getState: () => unknown;
@@ -453,6 +454,19 @@ cliInput.addEventListener('input', () => {
 		setSelectedModel(match, true, matches);
 	} else {
 		setNoMatch();
+	}
+});
+
+window.addEventListener('keydown', (event) => {
+	if (document.body.classList.contains('is-smart-mode')) {
+		const shortcutMatch = matchAgentShortcut(event);
+		if (shortcutMatch) {
+			event.preventDefault();
+			const matchedModel = models.find((m) => m.label === shortcutMatch.agentLabel);
+			if (matchedModel) {
+				openModel(matchedModel);
+			}
+		}
 	}
 });
 

--- a/src/shared/keymaps/cli.ts
+++ b/src/shared/keymaps/cli.ts
@@ -1,3 +1,5 @@
+import { getCliAgent, cliAgents } from '../../my-cli/shared/agents';
+
 // ─── Matcher factories ────────────────────────────────────────────────────────
 
 function altKey(targetKey: string): (event: KeyboardEvent) => boolean {
@@ -219,4 +221,42 @@ export function consumeShortcut(event: KeyboardEvent, id: ShortcutId): boolean {
     return true;
   }
   return false;
+}
+
+// ─── Agent Shortcuts ────────────────────────────────────────────────────────
+// Number 1-9 shortcuts to open specific agents in the launcher.
+
+function numKey(num: number): (event: KeyboardEvent) => boolean {
+  return (e: KeyboardEvent) => {
+    // We want plain numbers 1-9 without modifiers
+    if (e.altKey || e.ctrlKey || e.metaKey) { return false; }
+    // Accept main keyboard number or numpad number
+    return e.key === String(num) || e.code === `Numpad${num}`;
+  };
+}
+
+export type AgentShortcutDefinition = {
+  id: string;
+  label: string;
+  agentLabel: string;
+  match: (event: KeyboardEvent) => boolean;
+};
+
+export const agentShortcuts: AgentShortcutDefinition[] = [];
+
+// Create shortcuts dynamically based on the current order of cliAgents
+cliAgents.forEach((agent, index) => {
+  const num = index + 1;
+  if (num <= 9) {
+    agentShortcuts.push({
+      id: `openAgent${num}`,
+      label: `Open ${agent.label}`,
+      agentLabel: agent.label,
+      match: numKey(num),
+    });
+  }
+});
+
+export function matchAgentShortcut(event: KeyboardEvent): AgentShortcutDefinition | undefined {
+  return agentShortcuts.find((s) => s.match(event));
 }


### PR DESCRIPTION
This pull request makes several improvements to the CLI launcher experience, focusing on keyboard accessibility, agent switching, and UI consistency. Notably, it introduces number key shortcuts to quickly select agents, refines palette/tab navigation, and updates some UI styles for clarity and better feedback. It also expands the spellcheck dictionary and protected terms.

**Launcher keyboard and agent switching enhancements:**

* Added number key shortcuts (1-9) to quickly switch to specific agents in the launcher, with logic in `src/shared/keymaps/cli.ts` and integration in the launcher webview (`index.ts`). ([src/shared/keymaps/cli.tsR1-R2](diffhunk://#diff-9dad4345f014979e33fb7c4ca1ab242611e13ef8737443731438da4a10c0aca4R1-R2), Fb3e6872L419R419)
* Simplified palette navigation: removed palette open/close toggling with Tab, and now Tab toggles the footer panel. Agent options are always tabbable for better accessibility. ([src/my-cli/webview/launcher/index.tsL289-L295](diffhunk://#diff-35fcb85594f612e568705cb5ce331cc20fc1aa5427e5b820ae5b607adce9c16aL289-L295), Fb3e6872L322R322)
* When switching between "smart mode" and regular mode, the CLI input is now disabled and cleared in smart mode, and restored when returning, improving focus and state management. (Fb3e6872L465R465)

**UI and style updates:**

* Updated agent icon option hover and preview status styles for improved visual clarity, using more consistent accent colors and subtle shadows. [[1]](diffhunk://#diff-82aba3f264874f94ce36eca83475a29d496b6b132d2ac4fdd55bb38aca1ca5deL233-R237) [[2]](diffhunk://#diff-82aba3f264874f94ce36eca83475a29d496b6b132d2ac4fdd55bb38aca1ca5deL357-L363) F62536ebL588R588)
* Changed the shortcut legend in the launcher UI for clarity.

**Spellcheck and protected terms:**

* Expanded the `PERSONAL_MISTAKES` dictionary with additional common misspellings and added new protected terms for better spellcheck coverage. [[1]](diffhunk://#diff-5f1b678d253b14185443d31bc41152b50fee23839dd9e504ad35432a19cbcffeR24-R36) [[2]](diffhunk://#diff-2cc612d493851db89bf2a281b5f9dcc01ed2c3bb4463a5fde6d8a48b4c61ff27L3-R3)

**Other improvements:**

* The tutorial button now opens the external tutorial link directly, rather than calling an internal method.

These changes collectively make the CLI launcher more intuitive and efficient to use, especially for keyboard users, while also improving UI consistency and spellcheck accuracy.