### PR TITLE
🛠️ Enhance CLI with persistent voice control and state management

### DIFF
--- a/src/my-cli/webview/panel-tab/tab.css
+++ b/src/my-cli/webview/panel-tab/tab.css
@@ -1073,3 +1073,135 @@
 		display: none;
 	}
 }
+
+/* ── Header voice pill — the read-aloud "now playing" control mirrored into the
+   always-visible CLI bar so a voice can be paused/stopped without an open modal.
+   Same green treatment as the modal pills; only shown while a read is live.
+   Keyframes are cliv-* (not the modal's pv-*) so the two stylesheets don't clash. */
+.cli-voice-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+	padding: 2px 4px;
+	border-radius: 999px;
+	background: color-mix(in srgb, #5DCAA5 13%, transparent);
+	border: 0.5px solid color-mix(in srgb, #5DCAA5 30%, transparent);
+}
+.cli-voice-pill[hidden] {
+	display: none;
+}
+
+.cli-voice-toggle,
+.cli-voice-stop {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	color: #5DCAA5;
+}
+.cli-voice-toggle {
+	width: 30px;
+	height: 20px;
+}
+.cli-voice-toggle:disabled {
+	cursor: default;
+}
+.cli-voice-stop {
+	width: 18px;
+	height: 18px;
+	border-radius: 6px;
+	color: color-mix(in srgb, #5DCAA5 70%, var(--vscode-foreground));
+	transition: background 0.15s ease, color 0.15s ease;
+}
+.cli-voice-stop:hover {
+	background: color-mix(in srgb, #f87171 24%, transparent);
+	color: #f87171;
+}
+
+/* Play glyph only while paused; spectrum only while speaking. */
+.cli-voice-play {
+	position: absolute;
+	inset: 0;
+	margin: auto;
+	display: none;
+}
+.cli-voice-pill.is-paused .cli-voice-play {
+	display: block;
+}
+
+.cli-voice-spectrum {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 2px;
+	opacity: 0;
+	transition: opacity 0.2s ease;
+	pointer-events: none;
+}
+.cli-voice-pill.is-speaking .cli-voice-spectrum {
+	opacity: 1;
+}
+.cli-voice-pill.is-preparing .cli-voice-spectrum {
+	opacity: 0.85;
+}
+
+.cli-voice-spectrum .bar {
+	width: 2.5px;
+	border-radius: 999px;
+	background: linear-gradient(180deg, #eafff6 0%, #5DCAA5 60%, #3fa583 100%);
+	opacity: 0.9;
+}
+.cli-voice-spectrum .bar:nth-child(1) { height: 5px; }
+.cli-voice-spectrum .bar:nth-child(2) { height: 12px; }
+.cli-voice-spectrum .bar:nth-child(3) { height: 16px; }
+.cli-voice-spectrum .bar:nth-child(4) { height: 9px; }
+.cli-voice-spectrum .bar:nth-child(5) { height: 14px; }
+.cli-voice-spectrum .bar:nth-child(6) { height: 7px; }
+
+.cli-voice-pill.is-speaking .bar:nth-child(1) { animation: cliv-low  520ms ease-in-out -120ms infinite alternate; }
+.cli-voice-pill.is-speaking .bar:nth-child(2) { animation: cliv-mid  370ms ease-in-out -240ms infinite alternate; }
+.cli-voice-pill.is-speaking .bar:nth-child(3) { animation: cliv-high 430ms ease-in-out  -60ms infinite alternate; }
+.cli-voice-pill.is-speaking .bar:nth-child(4) { animation: cliv-mid  480ms ease-in-out -330ms infinite alternate; }
+.cli-voice-pill.is-speaking .bar:nth-child(5) { animation: cliv-high 340ms ease-in-out -180ms infinite alternate; }
+.cli-voice-pill.is-speaking .bar:nth-child(6) { animation: cliv-low  410ms ease-in-out -280ms infinite alternate; }
+
+/* Preparing / buffering — keep the meter moving but grey, so a gap reads as
+   "loading" instead of a frozen bar. */
+.cli-voice-pill.is-preparing .bar {
+	background: linear-gradient(180deg, #d3dbd8 0%, #8b948f 60%, #69716d 100%);
+}
+.cli-voice-pill.is-preparing .bar:nth-child(1) { animation: cliv-low  660ms ease-in-out -120ms infinite alternate; }
+.cli-voice-pill.is-preparing .bar:nth-child(2) { animation: cliv-mid  520ms ease-in-out -240ms infinite alternate; }
+.cli-voice-pill.is-preparing .bar:nth-child(3) { animation: cliv-high 580ms ease-in-out  -60ms infinite alternate; }
+.cli-voice-pill.is-preparing .bar:nth-child(4) { animation: cliv-mid  620ms ease-in-out -330ms infinite alternate; }
+.cli-voice-pill.is-preparing .bar:nth-child(5) { animation: cliv-high 480ms ease-in-out -180ms infinite alternate; }
+.cli-voice-pill.is-preparing .bar:nth-child(6) { animation: cliv-low  560ms ease-in-out -280ms infinite alternate; }
+
+@keyframes cliv-low {
+	0%   { height: 3px;  opacity: 0.55; }
+	60%  { height: 9px; }
+	100% { height: 12px; opacity: 0.95; }
+}
+@keyframes cliv-mid {
+	0%   { height: 4px;  opacity: 0.6; }
+	45%  { height: 13px; }
+	100% { height: 16px; opacity: 1; }
+}
+@keyframes cliv-high {
+	0%   { height: 5px;  opacity: 0.65; }
+	55%  { height: 12px; }
+	100% { height: 19px; opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cli-voice-pill.is-speaking .bar,
+	.cli-voice-pill.is-preparing .bar {
+		animation: none !important;
+	}
+}

--- a/src/my-cli/webview/panel-tab/tab.css
+++ b/src/my-cli/webview/panel-tab/tab.css
@@ -811,7 +811,7 @@
 		grid-column: 2;
 		grid-row: 1;
 		align-self: center;
-		justify-self: start;
+		justify-self: start; /*TODO: end - start*/
 	}
 
 	.agent-picker {

--- a/src/my-cli/webview/panel-tab/tab.css
+++ b/src/my-cli/webview/panel-tab/tab.css
@@ -787,7 +787,7 @@
 
 	.agent-tab-shell {
 		display: grid;
-		grid-template-columns: minmax(0, 1fr) minmax(112px, 166px) auto;
+		grid-template-columns: auto minmax(0, 1fr) minmax(112px, 166px) auto;
 		grid-template-rows: 1fr;
 		align-items: center;
 		gap: 7px;
@@ -802,8 +802,20 @@
 		display: contents;
 	}
 
-	.agent-picker {
+	.agent-session-list {
+		grid-column: 1;
+		grid-row: 1;
+	}
+
+	#cli-voice-pill {
 		grid-column: 2;
+		grid-row: 1;
+		align-self: center;
+		justify-self: start;
+	}
+
+	.agent-picker {
+		grid-column: 3;
 		grid-row: 1;
 		flex: 0 1 auto;
 	}
@@ -815,7 +827,7 @@
 	}
 
 	.agent-header-actions {
-		grid-column: 3;
+		grid-column: 4;
 		grid-row: 1;
 		gap: 4px;
 		margin-left: 0;
@@ -843,8 +855,6 @@
 	}
 
 	.agent-session-list {
-		grid-column: 1;
-		grid-row: 1;
 		min-height: 34px;
 		display: flex;
 		flex-direction: row;

--- a/src/my-cli/webview/panel-tab/tab.html
+++ b/src/my-cli/webview/panel-tab/tab.html
@@ -1,6 +1,25 @@
 <div class="layout-left">
 	<div class="agent-tab-shell">
 		<div class="agent-tab-header">
+			<!-- Read-aloud "now playing" mirrored into the always-visible CLI bar:
+			     pause/resume/stop a live voice without an open modal. Shown only
+			     while a read is live; fed from voice.state in terminal.ts. -->
+			<div id="cli-voice-pill" class="cli-voice-pill" hidden aria-hidden="true">
+				<button id="cli-voice-toggle" class="cli-voice-toggle" type="button" title="Pause voice" aria-label="Pause voice">
+					<svg class="cli-voice-play" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<path d="M7 4v16l13 -8z" />
+					</svg>
+					<div class="cli-voice-spectrum" aria-hidden="true">
+						<div class="bar"></div><div class="bar"></div><div class="bar"></div>
+						<div class="bar"></div><div class="bar"></div><div class="bar"></div>
+					</div>
+				</button>
+				<button id="cli-voice-stop" class="cli-voice-stop" type="button" title="Stop voice" aria-label="Stop voice">
+					<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<rect x="6" y="6" width="12" height="12" rx="2.5" />
+					</svg>
+				</button>
+			</div>
 			<div class="agent-picker">
 				<button
 					id="cli-agent-button"
@@ -19,25 +38,6 @@
 				<div id="cli-agent-menu" class="agent-picker-menu" role="listbox" aria-label="CLI agent" hidden></div>
 			</div>
 			<div class="agent-header-actions">
-				<!-- Read-aloud "now playing" mirrored into the always-visible CLI bar:
-				     pause/resume/stop a live voice without an open modal. Shown only
-				     while a read is live; fed from voice.state in terminal.ts. -->
-				<div id="cli-voice-pill" class="cli-voice-pill" hidden aria-hidden="true">
-					<button id="cli-voice-toggle" class="cli-voice-toggle" type="button" title="Pause voice" aria-label="Pause voice">
-						<svg class="cli-voice-play" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-							<path d="M7 4v16l13 -8z" />
-						</svg>
-						<div class="cli-voice-spectrum" aria-hidden="true">
-							<div class="bar"></div><div class="bar"></div><div class="bar"></div>
-							<div class="bar"></div><div class="bar"></div><div class="bar"></div>
-						</div>
-					</button>
-					<button id="cli-voice-stop" class="cli-voice-stop" type="button" title="Stop voice" aria-label="Stop voice">
-						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-							<rect x="6" y="6" width="12" height="12" rx="2.5" />
-						</svg>
-					</button>
-				</div>
 				<button
 					id="cli-tools-button"
 					class="agent-tools-button"

--- a/src/my-cli/webview/panel-tab/tab.html
+++ b/src/my-cli/webview/panel-tab/tab.html
@@ -19,6 +19,25 @@
 				<div id="cli-agent-menu" class="agent-picker-menu" role="listbox" aria-label="CLI agent" hidden></div>
 			</div>
 			<div class="agent-header-actions">
+				<!-- Read-aloud "now playing" mirrored into the always-visible CLI bar:
+				     pause/resume/stop a live voice without an open modal. Shown only
+				     while a read is live; fed from voice.state in terminal.ts. -->
+				<div id="cli-voice-pill" class="cli-voice-pill" hidden aria-hidden="true">
+					<button id="cli-voice-toggle" class="cli-voice-toggle" type="button" title="Pause voice" aria-label="Pause voice">
+						<svg class="cli-voice-play" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+							<path d="M7 4v16l13 -8z" />
+						</svg>
+						<div class="cli-voice-spectrum" aria-hidden="true">
+							<div class="bar"></div><div class="bar"></div><div class="bar"></div>
+							<div class="bar"></div><div class="bar"></div><div class="bar"></div>
+						</div>
+					</button>
+					<button id="cli-voice-stop" class="cli-voice-stop" type="button" title="Stop voice" aria-label="Stop voice">
+						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+							<rect x="6" y="6" width="12" height="12" rx="2.5" />
+						</svg>
+					</button>
+				</div>
 				<button
 					id="cli-tools-button"
 					class="agent-tools-button"

--- a/src/my-cli/webview/panel-terminal/terminal.ts
+++ b/src/my-cli/webview/panel-terminal/terminal.ts
@@ -1222,7 +1222,7 @@ const syncState = (message: Extract<ServerMessage, { type: 'cli.state' }>) => {
 		}
 		if (activeSessionId && promptOpenSessions.has(activeSessionId)) {
 			toolsController?.open('prompt');
-		} else if (leftPromptOpen) {
+		} else if (toolsController?.isOpen()) {
 			toolsController?.close({ keepVoice: true });
 		}
 	}

--- a/src/my-cli/webview/panel-terminal/terminal.ts
+++ b/src/my-cli/webview/panel-terminal/terminal.ts
@@ -350,7 +350,9 @@ const headerVoice = (() => {
 	let state: VoiceState = 'idle';
 	const apply = (next: VoiceState) => {
 		state = next;
-		const active = next === 'speaking' || next === 'paused' || next === 'preparing';
+		// Header pill intentionally hidden for now; keep state sync alive so a
+		// future flip just removes this override.
+		const active = false;
 		pill.hidden = !active;
 		pill.setAttribute('aria-hidden', active ? 'false' : 'true');
 		pill.classList.toggle('is-speaking', next === 'speaking');

--- a/src/my-cli/webview/panel-terminal/terminal.ts
+++ b/src/my-cli/webview/panel-terminal/terminal.ts
@@ -354,11 +354,11 @@ const headerVoice = (() => {
 		const active = state !== 'idle' && toolsController?.getOpenTool() !== 'translate';
 		pill.hidden = !active;
 		pill.setAttribute('aria-hidden', active ? 'false' : 'true');
-		pill.classList.toggle('is-speaking', next === 'speaking');
-		pill.classList.toggle('is-paused', next === 'paused');
-		pill.classList.toggle('is-preparing', next === 'preparing');
-		toggleBtn.disabled = next === 'preparing';
-		const label = next === 'preparing' ? 'Preparing voice…' : next === 'paused' ? 'Resume voice' : 'Pause voice';
+		pill.classList.toggle('is-speaking', state === 'speaking');
+		pill.classList.toggle('is-paused', state === 'paused');
+		pill.classList.toggle('is-preparing', state === 'preparing');
+		toggleBtn.disabled = state === 'preparing';
+		const label = state === 'preparing' ? 'Preparing voice…' : state === 'paused' ? 'Resume voice' : 'Pause voice';
 		toggleBtn.title = label;
 		toggleBtn.setAttribute('aria-label', label);
 	};

--- a/src/my-cli/webview/panel-terminal/terminal.ts
+++ b/src/my-cli/webview/panel-terminal/terminal.ts
@@ -350,8 +350,9 @@ const headerVoice = (() => {
 	let state: VoiceState = 'idle';
 	const apply = (next?: VoiceState) => {
 		if (next) state = next;
-		// Show the pill when voice is active but the translator modal is closed
-		const active = state !== 'idle' && toolsController?.getOpenTool() !== 'translate';
+		const openTool = toolsController?.getOpenTool();
+		// Show the pill when voice is active but voice modals (translator/prompt) are closed
+		const active = state !== 'idle' && openTool !== 'translate' && openTool !== 'prompt';
 		pill.hidden = !active;
 		pill.setAttribute('aria-hidden', active ? 'false' : 'true');
 		pill.classList.toggle('is-speaking', state === 'speaking');

--- a/src/my-cli/webview/panel-terminal/terminal.ts
+++ b/src/my-cli/webview/panel-terminal/terminal.ts
@@ -348,11 +348,10 @@ const headerVoice = (() => {
 	}
 
 	let state: VoiceState = 'idle';
-	const apply = (next: VoiceState) => {
-		state = next;
-		// Header pill intentionally hidden for now; keep state sync alive so a
-		// future flip just removes this override.
-		const active = false;
+	const apply = (next?: VoiceState) => {
+		if (next) state = next;
+		// Show the pill when voice is active but the translator modal is closed
+		const active = state !== 'idle' && toolsController?.getOpenTool() !== 'translate';
 		pill.hidden = !active;
 		pill.setAttribute('aria-hidden', active ? 'false' : 'true');
 		pill.classList.toggle('is-speaking', next === 'speaking');
@@ -575,6 +574,9 @@ const toolsController = layoutRight
 				const activePane = document.querySelector<HTMLElement>('.cli-terminal-pane.is-active');
 				activePane?.focus();
 			},
+			onToolChange: () => {
+				headerVoice?.apply();
+			},
 			refocusCli: () => {
 				// Ask the extension host to focus the CLI Hub view and then refocus
 				// the terminal. This is needed after Alt+number shortcuts because VS Code
@@ -610,7 +612,7 @@ const tabController = createTabController({
 	onSwitch: (sessionId) => vscode.postMessage({ type: 'cli.switch', sessionId }),
 	onClose: (sessionId) => vscode.postMessage({ type: 'cli.close', sessionId }),
 	onDismissToolModal: () => {
-		toolsController?.close();
+		toolsController?.close({ keepVoice: true });
 	},
 	onOpenTool: (tool) => {
 		toolsController?.toggle(tool);
@@ -1220,7 +1222,7 @@ const syncState = (message: Extract<ServerMessage, { type: 'cli.state' }>) => {
 		if (activeSessionId && promptOpenSessions.has(activeSessionId)) {
 			toolsController?.open('prompt');
 		} else if (leftPromptOpen) {
-			toolsController?.close();
+			toolsController?.close({ keepVoice: true });
 		}
 	}
 };
@@ -1374,7 +1376,7 @@ window.addEventListener('message', (event: MessageEvent<ServerMessage>) => {
 		// user returns. Dismiss it on hide. The Prompt modal is deliberately left
 		// alone so an in-progress draft survives the round-trip.
 		if (toolsController?.getOpenTool() === 'translate') {
-			toolsController.close();
+			toolsController.close({ keepVoice: true });
 		}
 		return;
 	}

--- a/src/my-cli/webview/panel-terminal/terminal.ts
+++ b/src/my-cli/webview/panel-terminal/terminal.ts
@@ -335,6 +335,55 @@ const onVoiceState = (listener: (state: VoiceState, message?: string, progress?:
 	};
 };
 
+// "Now playing" voice control mirrored into the always-visible CLI header bar, so
+// a read-aloud can be paused/stopped without an open modal. Fed straight from the
+// broadcast voice.state (see the message handler) — independent of the modal pills,
+// which register through onVoiceState above. Same visual/logic as the prompt pill.
+const headerVoice = (() => {
+	const pill = document.getElementById('cli-voice-pill');
+	const toggleBtn = document.getElementById('cli-voice-toggle') as HTMLButtonElement | null;
+	const stopBtn = document.getElementById('cli-voice-stop') as HTMLButtonElement | null;
+	if (!pill || !toggleBtn || !stopBtn) {
+		return undefined;
+	}
+
+	let state: VoiceState = 'idle';
+	const apply = (next: VoiceState) => {
+		state = next;
+		const active = next === 'speaking' || next === 'paused' || next === 'preparing';
+		pill.hidden = !active;
+		pill.setAttribute('aria-hidden', active ? 'false' : 'true');
+		pill.classList.toggle('is-speaking', next === 'speaking');
+		pill.classList.toggle('is-paused', next === 'paused');
+		pill.classList.toggle('is-preparing', next === 'preparing');
+		toggleBtn.disabled = next === 'preparing';
+		const label = next === 'preparing' ? 'Preparing voice…' : next === 'paused' ? 'Resume voice' : 'Pause voice';
+		toggleBtn.title = label;
+		toggleBtn.setAttribute('aria-label', label);
+	};
+
+	toggleBtn.addEventListener('click', () => {
+		if (state === 'speaking') {
+			pauseSpeech();
+		} else if (state === 'paused') {
+			resumeSpeech();
+		}
+	});
+	stopBtn.addEventListener('click', () => {
+		if (state === 'speaking' || state === 'paused') {
+			stopSpeech();
+		}
+	});
+
+	return { apply };
+})();
+
+// Sync now in case a read is already playing when this webview (re)builds — there's
+// no retainContextWhenHidden, so a panel switch remounts us mid-read.
+if (headerVoice) {
+	queryVoiceState();
+}
+
 const openPromptFromTerminal = (sessionId: string) => {
 	if (!isPromptFilterEnabled || !toolsController) {
 		return;
@@ -1222,6 +1271,7 @@ window.addEventListener('message', (event: MessageEvent<ServerMessage>) => {
 
 	if (message.type === 'voice.state') {
 		voiceStateListener?.(message.state, message.message, message.progress);
+		headerVoice?.apply(message.state);
 		return;
 	}
 

--- a/src/my-cli/webview/panel-terminal/terminal.ts
+++ b/src/my-cli/webview/panel-terminal/terminal.ts
@@ -349,7 +349,7 @@ const headerVoice = (() => {
 
 	let state: VoiceState = 'idle';
 	const apply = (next?: VoiceState) => {
-		if (next) state = next;
+		if (next) {state = next;}
 		const openTool = toolsController?.getOpenTool();
 		// Show the pill when voice is active but voice modals (translator/prompt) are closed
 		const active = state !== 'idle' && openTool !== 'translate' && openTool !== 'prompt';
@@ -1387,8 +1387,10 @@ window.addEventListener('message', (event: MessageEvent<ServerMessage>) => {
 	}
 });
 
+let resizeTimer: ReturnType<typeof setTimeout>;
 const resizeObserver = new ResizeObserver(() => {
-	fitTerminal();
+	clearTimeout(resizeTimer);
+	resizeTimer = setTimeout(() => fitTerminal(), 50);
 });
 resizeObserver.observe(terminalStack);
 

--- a/src/my-cli/webview/tools/tools.ts
+++ b/src/my-cli/webview/tools/tools.ts
@@ -56,7 +56,7 @@ export type ToolContext = {
 
 type ToolCleanup = () => void;
 type ToolMount = (host: HTMLElement, context: ToolContext) => void | ToolCleanup;
-export type ToolsControllerOptions = { container: HTMLElement } & Omit<ToolContext, 'close'>;
+export type ToolsControllerOptions = { container: HTMLElement; onToolChange?: (tool: ToolId | null) => void } & Omit<ToolContext, 'close'>;
 
 const modalId = 'cli-tools-modal';
 
@@ -106,7 +106,8 @@ export const createToolsController = ({
 	queryVoiceState,
 	onVoiceState,
 	refocusTerminal,
-	refocusCli
+	refocusCli,
+	onToolChange
 }: ToolsControllerOptions) => {
 	let activeModal: HTMLElement | null = null;
 	let currentTool: ToolId | null = null;
@@ -131,6 +132,8 @@ export const createToolsController = ({
 		activeModal = null;
 		currentTool = null;
 		skillsRefreshFn = null;
+		
+		onToolChange?.(null);
 
 		// Return focus using the host-provided function (uses real Terminal.focus()
 		// on the xterm instance so input works and no visible focus ring appears
@@ -268,6 +271,7 @@ export const createToolsController = ({
 		document.addEventListener('keydown', handleKeyDown, true);
 		activeModal = modal;
 		currentTool = tool;
+		onToolChange?.(tool);
 	};
 
 	const toggle = (tool: ToolId) => {


### PR DESCRIPTION
This pull request adds a new "now playing" voice control pill to the always-visible CLI header bar, allowing users to pause, resume, or stop a live read-aloud session without needing to open a modal. The implementation includes new UI elements, CSS for the pill and its animated spectrum meter, and logic to keep the pill in sync with voice state and modal visibility. Several updates were also made to the tools controller and event handling to support this feature.

**Voice control pill feature:**

* Added a new `cli-voice-pill` element to the CLI header in `tab.html`, with pause/resume and stop buttons, and an animated spectrum meter that reflects the current voice state.
* Implemented CSS for the `cli-voice-pill`, including state-based classes (`is-speaking`, `is-paused`, `is-preparing`), color, layout, and keyframe animations for the spectrum meter.
* Updated grid layout in `tab.css` to accommodate the new pill and ensure proper alignment of header elements. [[1]](diffhunk://#diff-b1122601af48ac109d4896f670952e676e4cc9dd7f9eaf1129d62005a45c56f0L790-R790) [[2]](diffhunk://#diff-b1122601af48ac109d4896f670952e676e4cc9dd7f9eaf1129d62005a45c56f0L805-R819) [[3]](diffhunk://#diff-b1122601af48ac109d4896f670952e676e4cc9dd7f9eaf1129d62005a45c56f0L818-R830) [[4]](diffhunk://#diff-b1122601af48ac109d4896f670952e676e4cc9dd7f9eaf1129d62005a45c56f0L846-L847)

**Voice state synchronization and logic:**

* Added `headerVoice` logic in `terminal.ts` to control the visibility, state, and accessibility of the pill, and to handle button actions for pausing, resuming, and stopping speech. The pill is shown only when a voice read is active and no modal is open.
* Ensured the pill stays in sync with the voice state and modal visibility by updating it on relevant events and tool changes. [[1]](diffhunk://#diff-1397ee8d896c7ad3e3ed3c6ff4867a86ccbefa1e864c7a3d7a4ea99660279304R578-R580) [[2]](diffhunk://#diff-1397ee8d896c7ad3e3ed3c6ff4867a86ccbefa1e864c7a3d7a4ea99660279304L1171-R1226) [[3]](diffhunk://#diff-1397ee8d896c7ad3e3ed3c6ff4867a86ccbefa1e864c7a3d7a4ea99660279304R1279)

**Tools controller and modal interaction:**

* Enhanced the tools controller to accept an `onToolChange` callback, allowing the header pill to update its state when modals are opened or closed. [[1]](diffhunk://#diff-388b649b915b64d0765d355feee6072cae55ec25a56e91a36a80c57a64c53ee5L59-R59) [[2]](diffhunk://#diff-388b649b915b64d0765d355feee6072cae55ec25a56e91a36a80c57a64c53ee5L109-R110) [[3]](diffhunk://#diff-388b649b915b64d0765d355feee6072cae55ec25a56e91a36a80c57a64c53ee5R136-R137) [[4]](diffhunk://#diff-388b649b915b64d0765d355feee6072cae55ec25a56e91a36a80c57a64c53ee5R274)
* Updated modal close logic to optionally keep the voice pill visible when closing a tool modal, ensuring voice controls remain accessible. [[1]](diffhunk://#diff-1397ee8d896c7ad3e3ed3c6ff4867a86ccbefa1e864c7a3d7a4ea99660279304L562-R616) [[2]](diffhunk://#diff-1397ee8d896c7ad3e3ed3c6ff4867a86ccbefa1e864c7a3d7a4ea99660279304L1171-R1226) [[3]](diffhunk://#diff-1397ee8d896c7ad3e3ed3c6ff4867a86ccbefa1e864c7a3d7a4ea99660279304L1325-R1380)

**Other improvements:**

* Added a debounced resize observer to prevent excessive terminal fitting on rapid resizes.